### PR TITLE
[MOBILE-376] update iOS and Android SDKs to 10.0.3, 9.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This library provides official bindings to the Urban Airship SDK, as well as sam
 
 ### Release Notes
 
+Version 9.3.1 – November 9, 2018
+================================
+- Update iOS SDK to 10.0.3
+- Update Android SDK to 9.5.4
+
 Version 9.3 - October 4, 2018
 =============================
 - Update iOS SDK to 10.0.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 10.0.1
+github "urbanairship/ios-library" == 10.0.3

--- a/UrbanAirship.Android.ADM.nuspec
+++ b/UrbanAirship.Android.ADM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.adm</id>
-      <version>9.5.2</version>
+      <version>9.5.4</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.2"/>
+            <dependency id="urbanairship.android.core" version="9.5.4"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.Core.nuspec
+++ b/UrbanAirship.Android.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.core</id>
-      <version>9.5.2</version>
+      <version>9.5.4</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.Android.FCM.nuspec
+++ b/UrbanAirship.Android.FCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.fcm</id>
-      <version>9.5.2</version>
+      <version>9.5.4</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -13,7 +13,7 @@
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.Firebase.Messaging" version="60.1142.1" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="60.1142.1" />
-            <dependency id="urbanairship.android.core" version="9.5.2"/>
+            <dependency id="urbanairship.android.core" version="9.5.4"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.GCM.nuspec
+++ b/UrbanAirship.Android.GCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.gcm</id>
-      <version>9.5.2</version>
+      <version>9.5.4</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.GooglePlayServices.Gcm" version="42.1021.1" />
-            <dependency id="urbanairship.android.core" version="9.5.2"/>
+            <dependency id="urbanairship.android.core" version="9.5.4"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>9.3.0</version>
+      <version>9.3.1</version>
       <title>Urban Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,11 +11,11 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.2"/>
+            <dependency id="urbanairship.android.core" version="9.5.4"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios" version="10.0.1"/>
+            <dependency id="urbanairship.ios" version="10.0.3"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>9.3.0</version>
+      <version>9.3.1</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,11 +11,11 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.2"/>
+            <dependency id="urbanairship.android.core" version="9.5.4"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios" version="10.0.1"/>
+            <dependency id="urbanairship.ios" version="10.0.3"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.iOS.AppExtensions.nuspec
+++ b/UrbanAirship.iOS.AppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.appextensions</id>
-      <version>10.0.1</version>
+      <version>10.0.3</version>
       <title>Urban Airship App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.nuspec
+++ b/UrbanAirship.iOS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios</id>
-      <version>10.0.1</version>
+      <version>10.0.3</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 9.3.0
-iosVersion = 10.0.1
-androidVersion = 9.5.2
+libVersion = 9.3.1
+iosVersion = 10.0.3
+androidVersion = 9.5.4

--- a/samples/android/Sample.csproj
+++ b/samples/android/Sample.csproj
@@ -13,10 +13,10 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AssemblyName>Sample</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <Description>Urban Airship Xamarin sample app for Android</Description>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -90,7 +90,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-adm-9.5.2.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-adm-9.5.4.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>UrbanAirship</RootNamespace>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AssemblyName>AirshipBindings.Core</AssemblyName>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
@@ -126,7 +126,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-core-9.5.2.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-core-9.5.4.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" />

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -10,9 +10,9 @@
     <RootNamespace>UrbanAirship</RootNamespace>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AssemblyName>AirshipBindings.FCM</AssemblyName>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
@@ -111,7 +111,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.5.2.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.5.4.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
+++ b/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
@@ -113,7 +113,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.5.2.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.5.4.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("9.3.0")]
+[assembly: AssemblyVersion ("9.3.1")]
 


### PR DESCRIPTION

### What do these changes do?
Updates the iOS and Android SDKs to their latest patch.

### Why are these changes necessary?
There were some nasty bugs we patched recently, so this will spare our Xamarin users some difficulty.

I also updated the UrbanAirship.Core/FCM packages as well as the sample to build using the latest mono android (9.0) instead of pegging things to 8.1. I believe the mixture of 8.1 and 9.0 artifacts was causing some silent deployment errors resulting in Firebase woes, and we should probably be reflexively targeting the latest SDK version anyway.
  
### How did you verify these changes?
Manually testing the sample app for iOS and Android.
