### PR TITLE
[android-9.5.5-patch] update android SDK to 9.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This library provides official bindings to the Urban Airship SDK, as well as sam
 
 ### Release Notes
 
+Version 9.3.2 - November 14, 2018
+=================================
+- Update Android SDK to 9.5.4
+- iOS SDK remains at 10.0.3
+
 Version 9.3.1 – November 9, 2018
 ================================
 - Update iOS SDK to 10.0.3

--- a/UrbanAirship.Android.ADM.nuspec
+++ b/UrbanAirship.Android.ADM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.adm</id>
-      <version>9.5.4</version>
+      <version>9.5.5</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.4"/>
+            <dependency id="urbanairship.android.core" version="9.5.5"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.Core.nuspec
+++ b/UrbanAirship.Android.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.core</id>
-      <version>9.5.4</version>
+      <version>9.5.5</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.Android.FCM.nuspec
+++ b/UrbanAirship.Android.FCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.fcm</id>
-      <version>9.5.4</version>
+      <version>9.5.5</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -13,7 +13,7 @@
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.Firebase.Messaging" version="60.1142.1" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="60.1142.1" />
-            <dependency id="urbanairship.android.core" version="9.5.4"/>
+            <dependency id="urbanairship.android.core" version="9.5.5"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.GCM.nuspec
+++ b/UrbanAirship.Android.GCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.gcm</id>
-      <version>9.5.4</version>
+      <version>9.5.5</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.GooglePlayServices.Gcm" version="42.1021.1" />
-            <dependency id="urbanairship.android.core" version="9.5.4"/>
+            <dependency id="urbanairship.android.core" version="9.5.5"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>9.3.1</version>
+      <version>9.3.2</version>
       <title>Urban Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.4"/>
+            <dependency id="urbanairship.android.core" version="9.5.5"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>9.3.1</version>
+      <version>9.3.2</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.4"/>
+            <dependency id="urbanairship.android.core" version="9.5.5"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 9.3.1
+libVersion = 9.3.2
 iosVersion = 10.0.3
-androidVersion = 9.5.4
+androidVersion = 9.5.5

--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -90,7 +90,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-adm-9.5.4.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-adm-9.5.5.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -126,7 +126,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-core-9.5.4.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-core-9.5.5.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" />

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -111,7 +111,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.5.4.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.5.5.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
+++ b/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
@@ -113,7 +113,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.5.4.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.5.5.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("9.3.1")]
+[assembly: AssemblyVersion ("9.3.2")]
 


### PR DESCRIPTION
### What do these changes do?
Updates Android SDK to 9.5.5

### Why are these changes necessary?
9.5.5 fixes a fairly critical bug, so we want to make sure our framework users are covered.

### How did you verify these changes?
Manual testing of the sample app. Nothing has changed beyond the version of the incorporated aar, and the android update itself is quite small.
