### PR TITLE
[release-9.4.0] update android sdk references to 9.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This library provides official bindings to the Urban Airship SDK, as well as sam
 
 ### Release Notes
 
+Version 9.4.0 - March 14, 2019
+==============================
+Fixed a security issue within Urban Airship SDK, that could allow trusted URL redirects in certain
+edge cases. All applications that are using urbanairship.android packages from 9.2.0 - 9.5.6,
+or urbanairship.netstandard packages 9.0.0 - 9.3.3, should update as soon as possible. 
+For more details, please email security@urbanairship.com.
+
+- Update Android SDK to 9.7.2
+- iOS SDK remains at 10.0.3
+
 Version 9.3.3 - November 20, 2018
 =================================
 - Update Android SDK to 9.5.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This library provides official bindings to the Urban Airship SDK, as well as sam
 Version 9.4.0 - March 14, 2019
 ==============================
 Fixed a security issue within Urban Airship SDK, that could allow trusted URL redirects in certain
-edge cases. All applications that are using urbanairship.android packages from 9.2.0 - 9.5.6,
-or urbanairship.netstandard packages 9.0.0 - 9.3.3, should update as soon as possible. 
+edge cases. Affected package versions include the deprecated urbanairship package 5.0.0 - 5.0.2, the 
+urbanairship.android packages 9.2.0 - 9.5.6, as well as the urbanairship.netstandard and 
+urbanairship.portable packages 9.0.0 - 9.3.3. Apps using any of these should update as soon as possible. 
 For more details, please email security@urbanairship.com.
 
 - Update Android SDK to 9.7.2

--- a/UrbanAirship.Android.ADM.nuspec
+++ b/UrbanAirship.Android.ADM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.adm</id>
-      <version>9.5.6</version>
+      <version>9.7.1</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.6"/>
+            <dependency id="urbanairship.android.core" version="9.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.Core.nuspec
+++ b/UrbanAirship.Android.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.core</id>
-      <version>9.5.6</version>
+      <version>9.7.1</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.Android.FCM.nuspec
+++ b/UrbanAirship.Android.FCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.fcm</id>
-      <version>9.5.6</version>
+      <version>9.7.1</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -13,7 +13,7 @@
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.Firebase.Messaging" version="60.1142.1" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="60.1142.1" />
-            <dependency id="urbanairship.android.core" version="9.5.6"/>
+            <dependency id="urbanairship.android.core" version="9.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.GCM.nuspec
+++ b/UrbanAirship.Android.GCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.android.gcm</id>
-      <version>9.5.6</version>
+      <version>9.7.1</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.GooglePlayServices.Gcm" version="42.1021.1" />
-            <dependency id="urbanairship.android.core" version="9.5.6"/>
+            <dependency id="urbanairship.android.core" version="9.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>9.3.3</version>
+      <version>9.4.0</version>
       <title>Urban Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.6"/>
+            <dependency id="urbanairship.android.core" version="9.7.1"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>9.3.3</version>
+      <version>9.4.0</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship.android.core" version="9.5.6"/>
+            <dependency id="urbanairship.android.core" version="9.7.1"/>
          </group>
 
          <group targetFramework="Xamarin.iOS">

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 9.3.3
+libVersion = 9.4.0
 iosVersion = 10.0.3
-androidVersion = 9.5.6
+androidVersion = 9.7.1

--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -90,7 +90,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-adm-9.5.6.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-adm-9.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -126,7 +126,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-core-9.5.6.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-core-9.7.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" />

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -111,7 +111,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.5.6.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-fcm-9.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
+++ b/src/AirshipBindings.Android.GCM/AirshipBindings.Android.GCM.csproj
@@ -113,7 +113,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.5.6.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-gcm-9.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("9.3.3")]
+[assembly: AssemblyVersion ("9.4.0")]
 


### PR DESCRIPTION
One of the many plugin releases today in the aftermath of https://github.com/urbanairship/android-library-dev/pull/521, which necessitated an android version bump. For more context, see

urbanairship/android-library#115
urbanairship/android-library#114

