### PR TITLE
iOS Release 11.1 & NuGet Package fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This library provides official bindings to the Airship SDK, as well as sample ap
 
 ### Release Notes
 
-Versions 10.0.1 (.NETStandard & PCL), 11.1.0 (iOS) - July 11, 2019
+Versions 10.1.0 (.NETStandard & PCL), 11.1.0 (iOS) - July 11, 2019
 ===================================================================================
 - Update iOS SDK to 11.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This library provides official bindings to the Airship SDK, as well as sample ap
 
 ### Release Notes
 
+Versions 10.0.1 (.NETStandard & PCL), 11.1.0 (iOS) - July 11, 2019
+===================================================================================
+- Update iOS SDK to 11.1.0
+
+Changes
+-------
+- Fixed problem with installation of new iOS LocationKit package.
+
 Versions 10.0.0 (.NETStandard & PCL), 10.0.2 (Android), 11.0.0 (iOS) - July 1, 2019
 ===================================================================================
 - Update Android SDK to 10.0.2

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 11.0.0
+github "urbanairship/ios-library" == 11.1.0

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -97,9 +97,9 @@ Xamarin application.
     ```
 
 ### Platform Documentation
-- iOS: http://docs.urbanairship.com/platform/ios.html
-- Android: http://docs.urbanairship.com/platform/android.html
-- Topic guides: http://docs.urbanairship.com/topic-guides/index.html
+- iOS: http://docs.airship.com/platform/ios.html
+- Android: http://docs.airship.com/platform/android.html
+- Topic guides: http://docs.airship.com/topic-guides/index.html
 
 ### Support
-- https://support.urbanairship.com
+- https://support.airship.com

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>10.0.1</version>
+      <version>10.1.0</version>
       <title>Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>10.0.0</version>
+      <version>10.0.1</version>
       <title>Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -15,7 +15,7 @@
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios" version="11.0.0"/>
+            <dependency id="urbanairship.ios" version="11.1.0"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>10.0.1</version>
+      <version>10.1.0</version>
       <title>Airship SDK Portable Client Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>10.0.0</version>
+      <version>10.0.1</version>
       <title>Airship SDK Portable Client Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -15,7 +15,7 @@
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios" version="11.0.0"/>
+            <dependency id="urbanairship.ios" version="11.1.0"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.iOS.AppExtensions.nuspec
+++ b/UrbanAirship.iOS.AppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.appextensions</id>
-      <version>11.0.0</version>
+      <version>11.1.0</version>
       <title>Airship iOS SDK - App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.LocationKit.nuspec
+++ b/UrbanAirship.iOS.LocationKit.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.locationkit</id>
-      <version>11.0.0</version>
+      <version>11.1.0</version>
       <title>Airship iOS SDK - Location Kit</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,6 +11,6 @@
    </metadata>
 
    <files>
-     <file src="src/AirshipBindings.iOS.LocationKit/bin/release/AirshipBindings.iOS.LocationKit.dll" target="lib/Xamarin.iOS11" />
+     <file src="src/AirshipBindings.iOS.LocationKit/bin/release/AirshipBindings.iOS.LocationKit.dll" target="lib/Xamarin.iOS10" />
    </files>
 </package>

--- a/UrbanAirship.iOS.nuspec
+++ b/UrbanAirship.iOS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios</id>
-      <version>11.0.0</version>
+      <version>11.1.0</version>
       <title>Airship iOS SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-crossPlatformVersion = 10.0.1
+crossPlatformVersion = 10.1.0
 iosVersion = 11.1.0
 androidVersion = 10.0.2

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-crossPlatformVersion = 10.0.0
-iosVersion = 11.0.0
+crossPlatformVersion = 10.0.1
+iosVersion = 11.1.0
 androidVersion = 10.0.2

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("10.0.1")]
+[assembly: AssemblyVersion ("10.1.0")]
 

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("10.0.0")]
+[assembly: AssemblyVersion ("10.0.1")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("11.0.0")]
+[assembly: AssemblyVersion ("11.1.0")]
 


### PR DESCRIPTION
### What do these changes do?
Update the iOS SDK to 11.1 and fix an [issue](https://github.com/urbanairship/urbanairship-xamarin/issues/116) with the LocationKit nuget package.

### Why are these changes necessary?
- Customers couldn't install the LocationKit nuget package.
- Keep frameworks updated with the latest SDKs.

### How did you verify these changes?
Local builds. Also created a local nuget repo and successfully installed the LocationKit NuGet package.