### PR TITLE
[MOBLE-1296] fix custom event properties in netstandard/portable libs

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Analytics/CustomEvent.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Analytics/CustomEvent.cs
@@ -129,10 +129,11 @@ namespace UrbanAirship.NETStandard.Analytics
         }
 
         //@cond IGNORE
+
         public class Property<T> : IProperty
         {
-            public string name;
-            public T value;
+            public string name { get; private set; }
+            public T value { get; private set; }
 
             public Property(string name, T value)
             {
@@ -141,10 +142,10 @@ namespace UrbanAirship.NETStandard.Analytics
             }
         }
 
-        public interface IProperty
-        {
-
+        public interface IProperty {
+            string name { get; }
         }
+
         //@endcond
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using UrbanAirship.NETStandard.Analytics;
 
 namespace UrbanAirship.NETStandard
 {
@@ -78,7 +79,7 @@ namespace UrbanAirship.NETStandard
             UAirship.Push().UpdateRegistration();
         }
 
-        public void AddCustomEvent(NETStandard.Analytics.CustomEvent customEvent)
+        public void AddCustomEvent(CustomEvent customEvent)
         {
             if (customEvent == null || string.IsNullOrEmpty(customEvent.EventName))
             {
@@ -110,28 +111,28 @@ namespace UrbanAirship.NETStandard
 
             if (customEvent.PropertyList != null)
             {
-                foreach (dynamic property in customEvent.PropertyList)
+                foreach (var property in customEvent.PropertyList)
                 {
                     if (string.IsNullOrEmpty(property.name))
                     {
                         continue;
                     }
 
-                    if (property.value is string)
+                    if (property is CustomEvent.Property<string> stringProperty)
                     {
-                        uaEvent.SetStringProperty(property.stringValue, property.name);
+                        uaEvent.SetStringProperty(stringProperty.value, stringProperty.name);
                     }
-                    else if (property.value is double)
+                    else if (property is CustomEvent.Property<double> doubleProperty)
                     {
-                        uaEvent.SetNumberProperty(property.doubleValue, property.name);
+                        uaEvent.SetNumberProperty(doubleProperty.value, doubleProperty.name);
                     }
-                    else if (property.value is bool)
+                    else if (property is CustomEvent.Property<bool> boolProperty)
                     {
-                        uaEvent.SetBoolProperty(property.boolValue, property.name);
+                        uaEvent.SetBoolProperty(boolProperty.value, boolProperty.name);
                     }
-                    else if (property.value is string[])
+                    else if (property is CustomEvent.Property<string[]> stringArrayProperty)
                     {
-                        uaEvent.SetStringArrayProperty(property.stringArrayValue, property.name);
+                        uaEvent.SetStringArrayProperty(stringArrayProperty.value, stringArrayProperty.name);
                     }
                 }
             }

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/Analytics/CustomEvent.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/Analytics/CustomEvent.cs
@@ -128,11 +128,13 @@ namespace UrbanAirship.Portable.Analytics
 			this.propertyList.Add(new Property<string[]>(name, value.ToArray()));
 		}
 
-                //@cond IGNORE
+		//@cond IGNORE
+		public abstract class Property { };
+
 		public class Property<T> : IProperty
 		{
-			public string name;
-			public T value;
+			public string name { get; private set; }
+			public T value { get; private set; }
 
 			public Property(string name, T value)
 			{
@@ -143,8 +145,8 @@ namespace UrbanAirship.Portable.Analytics
 
 		public interface IProperty
 		{
-
+			string name { get; }
 		}
-                //@endcond
+		//@endcond
 	}
 }

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.iOS/Airship.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.iOS/Airship.cs
@@ -4,215 +4,216 @@
 
 using System;
 using System.Collections.Generic;
+using UrbanAirship.Portable.Analytics;
 
 namespace UrbanAirship.Portable
 {
-	public class Airship : IAirship
-	{
-		private static Airship sharedAirship = new Airship();
+    public class Airship : IAirship
+    {
+        private static Airship sharedAirship = new Airship();
 
-		public static Airship Instance
-		{
-			get
-			{
-				return sharedAirship;
-			}
-		}
+        public static Airship Instance
+        {
+            get
+            {
+                return sharedAirship;
+            }
+        }
 
-		public bool UserNotificationsEnabled
-		{
-			get
-			{
-				return UAirship.Push().UserPushNotificationsEnabled;
-			}
+        public bool UserNotificationsEnabled
+        {
+            get
+            {
+                return UAirship.Push().UserPushNotificationsEnabled;
+            }
 
-			set
-			{
-				UAirship.Push().UserPushNotificationsEnabled = value;
-			}
-		}
+            set
+            {
+                UAirship.Push().UserPushNotificationsEnabled = value;
+            }
+        }
 
-		public IEnumerable<string> Tags
-		{
-			get
-			{
-				return UAirship.Channel().Tags;
-			}
-		}
+        public IEnumerable<string> Tags
+        {
+            get
+            {
+                return UAirship.Channel().Tags;
+            }
+        }
 
-		public string ChannelId
-		{
-			get
-			{
-				return UAirship.Channel().Identifier;
-			}
-		}
+        public string ChannelId
+        {
+            get
+            {
+                return UAirship.Channel().Identifier;
+            }
+        }
 
-		public string NamedUser
-		{
-			get
-			{
-				return UAirship.NamedUser().Identifier;
-			}
+        public string NamedUser
+        {
+            get
+            {
+                return UAirship.NamedUser().Identifier;
+            }
 
-			set
-			{
-				UAirship.NamedUser().Identifier = value;
-			}
-		}
+            set
+            {
+                UAirship.NamedUser().Identifier = value;
+            }
+        }
 
-		public Push.TagEditor EditDeviceTags()
-		{
-			return new Push.TagEditor(this.DeviceTagHelper);
-		}
+        public Push.TagEditor EditDeviceTags()
+        {
+            return new Push.TagEditor(this.DeviceTagHelper);
+        }
 
-		private void DeviceTagHelper(bool clear, string[] addTags, string[] removeTags)
-		{
-			if (clear)
-			{
-				UAirship.Channel().Tags = new string[] { };
-			}
+        private void DeviceTagHelper(bool clear, string[] addTags, string[] removeTags)
+        {
+            if (clear)
+            {
+                UAirship.Channel().Tags = new string[] { };
+            }
 
-			UAirship.Channel().AddTags(addTags);
-			UAirship.Channel().RemoveTags(removeTags);
-			UAirship.Push().UpdateRegistration();
-		}
+            UAirship.Channel().AddTags(addTags);
+            UAirship.Channel().RemoveTags(removeTags);
+            UAirship.Push().UpdateRegistration();
+        }
 
-		public void AddCustomEvent(Portable.Analytics.CustomEvent customEvent)
-		{
-			if (customEvent == null || string.IsNullOrEmpty(customEvent.EventName))
-			{
-				return;
-			}
+        public void AddCustomEvent(CustomEvent customEvent)
+        {
+            if (customEvent == null || string.IsNullOrEmpty(customEvent.EventName))
+            {
+                return;
+            }
 
-			string eventName = customEvent.EventName;
-			double eventValue = customEvent.EventValue;
-			string transactionId = customEvent.TransactionId;
-			string interactionType = customEvent.InteractionType;
-			string interactionId = customEvent.InteractionId;
+            string eventName = customEvent.EventName;
+            double eventValue = customEvent.EventValue;
+            string transactionId = customEvent.TransactionId;
+            string interactionType = customEvent.InteractionType;
+            string interactionId = customEvent.InteractionId;
 
-			UACustomEvent uaEvent = UACustomEvent.Event(eventName, eventValue);
+            UACustomEvent uaEvent = UACustomEvent.Event(eventName, eventValue);
 
-			if (!string.IsNullOrEmpty(transactionId))
-			{
-				uaEvent.TransactionID = transactionId;
-			}
+            if (!string.IsNullOrEmpty(transactionId))
+            {
+                uaEvent.TransactionID = transactionId;
+            }
 
-			if (!string.IsNullOrEmpty(interactionId))
-			{
-				uaEvent.InteractionID = interactionId;
-			}
+            if (!string.IsNullOrEmpty(interactionId))
+            {
+                uaEvent.InteractionID = interactionId;
+            }
 
-			if (!string.IsNullOrEmpty(interactionType))
-			{
-				uaEvent.InteractionType = interactionType;
-			}
+            if (!string.IsNullOrEmpty(interactionType))
+            {
+                uaEvent.InteractionType = interactionType;
+            }
 
-			if (customEvent.PropertyList != null)
-			{
-				foreach (dynamic property in customEvent.PropertyList)
-				{
-					if (string.IsNullOrEmpty(property.name))
-					{
-						continue;
-					}
+            if (customEvent.PropertyList != null)
+            {
+                foreach (var property in customEvent.PropertyList)
+                {
+                    if (string.IsNullOrEmpty(property.name))
+                    {
+                        continue;
+                    }
 
-					if (property.value is string)
-					{
-						uaEvent.SetStringProperty(property.stringValue, property.name);
-					}
-					else if (property.value is double)
-					{
-						uaEvent.SetNumberProperty(property.doubleValue, property.name);
-					}
-					else if (property.value is bool)
-					{
-						uaEvent.SetBoolProperty(property.boolValue, property.name);
-					}
-					else if (property.value is string[])
-					{
-						uaEvent.SetStringArrayProperty(property.stringArrayValue, property.name);
-					}
-				}
-			}
+                    if (property is CustomEvent.Property<string> stringProperty)
+                    {
+                        uaEvent.SetStringProperty(stringProperty.value, stringProperty.name);
+                    }
+                    else if (property is CustomEvent.Property<double> doubleProperty)
+                    {
+                        uaEvent.SetNumberProperty(doubleProperty.value, doubleProperty.name);
+                    }
+                    else if (property is CustomEvent.Property<bool> boolProperty)
+                    {
+                        uaEvent.SetBoolProperty(boolProperty.value, boolProperty.name);
+                    }
+                    else if (property is CustomEvent.Property<string[]> stringArrayProperty)
+                    {
+                        uaEvent.SetStringArrayProperty(stringArrayProperty.value, stringArrayProperty.name);
+                    }
+                }
+            }
 
-			UAirship.Analytics().AddEvent(uaEvent);
-		}
+            UAirship.Analytics().AddEvent(uaEvent);
+        }
 
-		public void AssociateIdentifier(string key, string identifier)
-		{
-			UAAssociatedIdentifiers identifiers = UAirship.Analytics().CurrentAssociatedDeviceIdentifiers();
-			identifiers.SetIdentifier(identifier, key);
-			UAirship.Analytics().AssociateDeviceIdentifiers(identifiers);
-		}
+        public void AssociateIdentifier(string key, string identifier)
+        {
+            UAAssociatedIdentifiers identifiers = UAirship.Analytics().CurrentAssociatedDeviceIdentifiers();
+            identifiers.SetIdentifier(identifier, key);
+            UAirship.Analytics().AssociateDeviceIdentifiers(identifiers);
+        }
 
-		public void DisplayMessageCenter()
-		{
-			UAMessageCenter.Shared().Display();
-		}
+        public void DisplayMessageCenter()
+        {
+            UAMessageCenter.Shared().Display();
+        }
 
-		public int MessageCenterUnreadCount
-		{
-			get
-			{
-				return (int)UAMessageCenter.Shared().MessageList.UnreadCount;
-			}
-		}
+        public int MessageCenterUnreadCount
+        {
+            get
+            {
+                return (int)UAMessageCenter.Shared().MessageList.UnreadCount;
+            }
+        }
 
-		public int MessageCenterCount
-		{
-			get
-			{
-				return (int)UAMessageCenter.Shared().MessageList.MessageCount();
-			}
-		}
+        public int MessageCenterCount
+        {
+            get
+            {
+                return (int)UAMessageCenter.Shared().MessageList.MessageCount();
+            }
+        }
 
-		public Push.TagGroupsEditor EditNamedUserTagGroups()
-		{
-			return new Push.TagGroupsEditor((List<Push.TagGroupsEditor.TagOperation> payload) =>
-			{
-				TagGroupHelper(payload, true);
-				UAirship.NamedUser().UpdateTags();
-			});
-		}
+        public Push.TagGroupsEditor EditNamedUserTagGroups()
+        {
+            return new Push.TagGroupsEditor((List<Push.TagGroupsEditor.TagOperation> payload) =>
+            {
+                TagGroupHelper(payload, true);
+                UAirship.NamedUser().UpdateTags();
+            });
+        }
 
-		public Push.TagGroupsEditor EditChannelTagGroups()
-		{
-			return new Push.TagGroupsEditor((List<Push.TagGroupsEditor.TagOperation> payload) =>
-			{
-				TagGroupHelper(payload, false);
-				UAirship.Push().UpdateRegistration();
-			});
-		}
+        public Push.TagGroupsEditor EditChannelTagGroups()
+        {
+            return new Push.TagGroupsEditor((List<Push.TagGroupsEditor.TagOperation> payload) =>
+            {
+                TagGroupHelper(payload, false);
+                UAirship.Push().UpdateRegistration();
+            });
+        }
 
-		private void TagGroupHelper(List<Push.TagGroupsEditor.TagOperation> operations, bool namedUser)
-		{
-			var namedUserActions = new Dictionary<Push.TagGroupsEditor.OperationType, Action<string, string[]>>()
-			{
-				{ Push.TagGroupsEditor.OperationType.ADD, (group, t) => UAirship.NamedUser().AddTags(t, group) },
-				{ Push.TagGroupsEditor.OperationType.REMOVE, (group, t) => UAirship.NamedUser().RemoveTags(t, group) },
-				{ Push.TagGroupsEditor.OperationType.SET, (group, t) => UAirship.NamedUser().SetTags(t, group) }
-			};
-			var channelActions = new Dictionary<Push.TagGroupsEditor.OperationType, Action<string, string[]>>()
-			{
-				{ Push.TagGroupsEditor.OperationType.ADD, (group, t) => UAirship.Channel().AddTags(t, group) },
-				{ Push.TagGroupsEditor.OperationType.REMOVE, (group, t) => UAirship.Channel().RemoveTags(t, group) },
-				{ Push.TagGroupsEditor.OperationType.SET, (group, t) => UAirship.Channel().SetTags(t, group) }
-			};
+        private void TagGroupHelper(List<Push.TagGroupsEditor.TagOperation> operations, bool namedUser)
+        {
+            var namedUserActions = new Dictionary<Push.TagGroupsEditor.OperationType, Action<string, string[]>>()
+            {
+                { Push.TagGroupsEditor.OperationType.ADD, (group, t) => UAirship.NamedUser().AddTags(t, group) },
+                { Push.TagGroupsEditor.OperationType.REMOVE, (group, t) => UAirship.NamedUser().RemoveTags(t, group) },
+                { Push.TagGroupsEditor.OperationType.SET, (group, t) => UAirship.NamedUser().SetTags(t, group) }
+            };
+            var channelActions = new Dictionary<Push.TagGroupsEditor.OperationType, Action<string, string[]>>()
+            {
+                { Push.TagGroupsEditor.OperationType.ADD, (group, t) => UAirship.Channel().AddTags(t, group) },
+                { Push.TagGroupsEditor.OperationType.REMOVE, (group, t) => UAirship.Channel().RemoveTags(t, group) },
+                { Push.TagGroupsEditor.OperationType.SET, (group, t) => UAirship.Channel().SetTags(t, group) }
+            };
 
-			var actions = namedUser ? namedUserActions : channelActions;
+            var actions = namedUser ? namedUserActions : channelActions;
 
-			foreach (Push.TagGroupsEditor.TagOperation operation in operations)
-			{
-				if (!Enum.IsDefined(typeof(Push.TagGroupsEditor.OperationType), operation.operationType))
-				{
-					continue;
-				}
+            foreach (Push.TagGroupsEditor.TagOperation operation in operations)
+            {
+                if (!Enum.IsDefined(typeof(Push.TagGroupsEditor.OperationType), operation.operationType))
+                {
+                    continue;
+                }
 
-				string[] tagArray = new string[operation.tags.Count];
-				operation.tags.CopyTo(tagArray, 0);
-				actions[operation.operationType](operation.group, tagArray);
-			}
-		}
-	}
+                string[] tagArray = new string[operation.tags.Count];
+                operation.tags.CopyTo(tagArray, 0);
+                actions[operation.operationType](operation.group, tagArray);
+            }
+        }
+    }
 }


### PR DESCRIPTION
We recenetly got a report that trying to add a custom event with properties causes crashes on iOS, when using the .NETStandard/Portable interface.

I think this has actually been a bug in .NETStandard/Portable for a while. The CustomEvent.Property<T> abstraction doesn't have properties defined for "stringValue", "boolValue", etc, but just a single value property that varies with the generic type. My best guess is that the compiler prevented us from catching it, due to the use of a "dynamic" keyword in the foreach loop. This effectively turns off static type checking, and defers issues with e.g. non-existent method calls to runtime.

This PR modifies those code paths to remove the use of "dynamic", perform explicit casting (checked by the compiler), and use the correct property.
 
Update:

Once I got a test app building, I found I needed to rework the use of generics/casting. It's fine now, and I've tested out adding custom events with all property types in a custom NETStandard forms app, with no problems. The same app code results a runtime binding exception using a version of the library built off the master branch. I think VS did some whitespace related reformatting that makes the Portable part of the refactor look bigger than it is, but it's the same code as NETStandard except for the namespace and imports.