### PR TITLE
MOBILE-1303

### DIFF
--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -15,10 +15,10 @@
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios.core" version="13.0.4"/>
-            <dependency id="urbanairship.ios.automation" version="13.0.4"/>
-            <dependency id="urbanairship.ios.extendedactions" version="13.0.4"/>
-            <dependency id="urbanairship.ios.messagecenter" version="13.0.4"/>
+            <dependency id="urbanairship.ios.core" version="13.1.0"/>
+            <dependency id="urbanairship.ios.automation" version="13.1.0"/>
+            <dependency id="urbanairship.ios.extendedactions" version="13.1.0"/>
+            <dependency id="urbanairship.ios.messagecenter" version="13.1.0"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -15,10 +15,10 @@
          </group>
 
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios.core" version="13.0.4"/>
-            <dependency id="urbanairship.ios.automation" version="13.0.4"/>
-            <dependency id="urbanairship.ios.extendedactions" version="13.0.4"/>
-            <dependency id="urbanairship.ios.messagecenter" version="13.0.4"/>
+            <dependency id="urbanairship.ios.core" version="13.1.0"/>
+            <dependency id="urbanairship.ios.automation" version="13.1.0"/>
+            <dependency id="urbanairship.ios.extendedactions" version="13.1.0"/>
+            <dependency id="urbanairship.ios.messagecenter" version="13.1.0"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.iOS.nuspec
+++ b/UrbanAirship.iOS.nuspec
@@ -11,10 +11,10 @@
 
       <dependencies>
          <group targetFramework="Xamarin.iOS">
-            <dependency id="urbanairship.ios.core" version="13.0.4"/>
-            <dependency id="urbanairship.ios.automation" version="13.0.4"/>
-            <dependency id="urbanairship.ios.extendedactions" version="13.0.4"/>
-            <dependency id="urbanairship.ios.messagecenter" version="13.0.4"/>
+            <dependency id="urbanairship.ios.core" version="13.1.0"/>
+            <dependency id="urbanairship.ios.automation" version="13.1.0"/>
+            <dependency id="urbanairship.ios.extendedactions" version="13.1.0"/>
+            <dependency id="urbanairship.ios.messagecenter" version="13.1.0"/>
          </group>
       </dependencies>
    </metadata>

--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,8 @@ task syncVersion {
 
         // handle urbanairship.ios dependencies
         ant.replaceregexp(
-            match: "<dependency id=\"urbanairship.ios\" version=\".*\"/>",
-            replace: "<dependency id=\"urbanairship.ios\" version=\"$iosNugetVersion\"/>",
+            match: "<dependency id=\"urbanairship.ios(.*)\" version=\".*\"/>",
+            replace: "<dependency id=\"urbanairship.ios\\1\" version=\"$iosNugetVersion\"/>",
             flags: "g"
         ) {
             fileset(dir: "$projectDir", includes: "UrbanAirship*.nuspec")

--- a/src/AirshipBindings.iOS.Automation/ApiDefinitions.cs
+++ b/src/AirshipBindings.iOS.Automation/ApiDefinitions.cs
@@ -64,10 +64,6 @@ namespace UrbanAirship {
         [Field("UAButtonHeightKey", "__Internal")]
         NSString UAButtonHeightKey { get; }
 
-        // extern NSString *const _Nonnull UAButtonStyleKey
-        [Field("UAButtonStyleKey", "__Internal")]
-        NSString UAButtonStyleKey { get; }
-
         // extern NSString *const UACancelSchedulesActionAll
         [Field("UACancelSchedulesActionAll", "__Internal")]
         NSString UACancelSchedulesActionAll { get; }
@@ -79,10 +75,6 @@ namespace UrbanAirship {
         // extern NSString *const UACancelSchedulesActionIDs
         [Field("UACancelSchedulesActionIDs", "__Internal")]
         NSString UACancelSchedulesActionIDs { get; }
-
-        // extern NSString *const _Nonnull UAFullScreenAdditonalPaddingKey
-        [Field("UAFullScreenAdditonalPaddingKey", "__Internal")]
-        NSString UAFullScreenAdditonalPaddingKey { get; }
 
         // extern NSString *const _Nonnull UAFullScreenBodyStyleKey
         [Field("UAFullScreenBodyStyleKey", "__Internal")]
@@ -192,10 +184,6 @@ namespace UrbanAirship {
         [Field("UAInAppMessageDisplayBehaviorImmediate", "__Internal")]
         NSString UAInAppMessageDisplayBehaviorImmediate { get; }
 
-        // static NSString *const UAInAppMessageDisplayCoordinatorIsReadyKey = @"isReady"
-        [Field("UAInAppMessageDisplayCoordinatorIsReadyKey", "__Internal")]
-        NSString UAInAppMessageDisplayCoordinatorIsReadyKey { get; }
-
         // extern NSString *const UAInAppMessageDurationKey
         [Field("UAInAppMessageDurationKey", "__Internal")]
         NSString UAInAppMessageDurationKey { get; }
@@ -268,10 +256,6 @@ namespace UrbanAirship {
         [Field("UALandingPageDefaultBorderRadiusPoints", "__Internal")]
         nfloat UALandingPageDefaultBorderRadiusPoints { get; }
 
-        // extern NSString *const _Nonnull UALandingPageFill
-        [Field("UALandingPageFill", "__Internal")]
-        NSString UALandingPageFill { get; }
-
         // extern NSString *const _Nonnull UALandingPageHeightKey
         [Field("UALandingPageHeightKey", "__Internal")]
         NSString UALandingPageHeightKey { get; }
@@ -287,10 +271,6 @@ namespace UrbanAirship {
         // extern NSString *const _Nonnull UALineSpacingKey
         [Field("UALineSpacingKey", "__Internal")]
         NSString UALineSpacingKey { get; }
-
-        // extern NSString *const _Nonnull UAMediaAdditionalPaddingKey
-        [Field("UAMediaAdditionalPaddingKey", "__Internal")]
-        NSString UAMediaAdditionalPaddingKey { get; }
 
         // extern NSString *const _Nonnull UAModalAdditionalPaddingKey
         [Field("UAModalAdditionalPaddingKey", "__Internal")]
@@ -443,11 +423,6 @@ namespace UrbanAirship {
         // extern NSString *const _Nonnull UATextAdditonalPaddingKey
         [Field("UATextAdditonalPaddingKey", "__Internal")]
         NSString UATextAdditonalPaddingKey { get; }
-
-        // extern NSString *const _Nonnull UATextSpacingKey
-        [Field("UATextSpacingKey", "__Internal")]
-        NSString UATextSpacingKey { get; }
-
     }
 
     // @interface UAActionAutomation : UAComponent

--- a/src/AirshipBindings.iOS.Core/ApiDefinitions.cs
+++ b/src/AirshipBindings.iOS.Core/ApiDefinitions.cs
@@ -154,10 +154,6 @@ namespace UrbanAirship {
         [Field("UANotificationDismissActionIdentifier", "__Internal")]
         NSString UANotificationDismissActionIdentifier { get; }
 
-        // static const UANotificationOptions UANotificationOptionNone = 0
-        [Field("UANotificationOptionNone", "__Internal")]
-        UANotificationOptions UANotificationOptionNone { get; }
-
         // extern NSString *const _Nonnull UAOpenExternalURLActionErrorDomain
         [Field("UAOpenExternalURLActionErrorDomain", "__Internal")]
         NSString UAOpenExternalURLActionErrorDomain { get; }

--- a/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
+++ b/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
@@ -106,6 +106,7 @@ namespace UrbanAirship {
     [Native]
     public enum UANotificationOptions : ulong
     {
+        None = 0,
         Badge = (1 << 0),
         Sound = (1 << 1),
         Alert = (1 << 2),


### PR DESCRIPTION
There were a few constants that were causing linker errors when building against the nupkg distribution. This doesn't seem to apply when testing using the "library project" sample, so we need to be more careful about testing using real packages in the future.

Nearly all of these are constants whose implementations have been removed from the SDK but for whatever reason didn't get removed from the headers. Two of them, namely UANotificationOptionNone and UAInAppMessageDisplayCoordinatorIsReadyKey are still in the SDK, but have inline definitions in the header file. We should probably also break the habit of doing this in the SDK, and Xamarin to my knowledge doesn't support binding them. I removed the latter for now, which is almost certainly something nobody will miss.

While I was testing I also noticed that several of the iOS nupkgs had out of date dependencies. VS was warning about this locally, because it matches the depdendency as >= and was selecting the latest version on disk. A remote package install probably would have resulted in silently installing the wrong dependency. It turned out build.gradle was doing the regex incorrectly, so I fixed the script as well.


 