### PR TITLE
[MOBILE-1310] add content extension to xamarin

### DIFF
--- a/samples/ios-unified/AirshipConfig.plist
+++ b/samples/ios-unified/AirshipConfig.plist
@@ -5,12 +5,12 @@
 	<key>inProduction</key>
 	<false/>
 	<key>developmentAppKey</key>
-	<string>Your Development App Key</string>
+	<string>Hx7SIqHqQDmFj6aruaAFcQ</string>
 	<key>developmentAppSecret</key>
-	<string>Your Development App Secret</string>
+	<string>JkyLL9IqQ2OVkashrzLq-A</string>
 	<key>productionAppKey</key>
-	<string>Your Production App Key</string>
+	<string>Hx7SIqHqQDmFj6aruaAFcQ</string>
 	<key>productionAppSecret</key>
-	<string>Your Production App Secret</string>
+	<string>JkyLL9IqQ2OVkashrzLq-A</string>
 </dict>
 </plist>

--- a/samples/ios-unified/AirshipConfig.plist
+++ b/samples/ios-unified/AirshipConfig.plist
@@ -5,12 +5,12 @@
 	<key>inProduction</key>
 	<false/>
 	<key>developmentAppKey</key>
-	<string>Hx7SIqHqQDmFj6aruaAFcQ</string>
+	<string>Your development app key</string>
 	<key>developmentAppSecret</key>
-	<string>JkyLL9IqQ2OVkashrzLq-A</string>
+	<string>Yopur development app secret</string>
 	<key>productionAppKey</key>
-	<string>Hx7SIqHqQDmFj6aruaAFcQ</string>
+	<string>Your production app keu</string>
 	<key>productionAppSecret</key>
-	<string>JkyLL9IqQ2OVkashrzLq-A</string>
+	<string>Your production app secret</string>
 </dict>
 </plist>

--- a/samples/ios-unified/AppDelegate.cs
+++ b/samples/ios-unified/AppDelegate.cs
@@ -62,6 +62,18 @@ namespace Sample
             messageCenterDelegate = new MessageCenterDelegate(Window.RootViewController);
             UAMessageCenter.Shared().DisplayDelegate = messageCenterDelegate;
 
+            UANotificationAction sampleAction = UANotificationAction.Action("sampleAction", title: "Sample Action Title", options:UANotificationActionOptions.Destructive);
+
+            var sampleActions = new UANotificationAction[] { sampleAction };
+            var intentIdentifiers = new string[] { };
+
+            // Create category for sample content extension
+            UANotificationCategory[] SampleCategoryArray = { UANotificationCategory.Category(identifier: "sample-extension-category", actions: sampleActions, intentIdentifiers: intentIdentifiers, options: UANotificationCategoryOptions.None) };
+            NSSet categories = NSSet.MakeNSObjectSet(SampleCategoryArray);
+
+            // Add sample content extension category to Airship custom categories
+            UAirship.Push().CustomCategories = categories;
+
             UAirship.Push().WeakRegistrationDelegate = this;
 
             NSString messageListUpdated = new NSString("com.urbanairship.notification.message_list_updated");

--- a/samples/ios-unified/SampleContentExtension/Entitlements.plist
+++ b/samples/ios-unified/SampleContentExtension/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/samples/ios-unified/SampleContentExtension/Info.plist
+++ b/samples/ios-unified/SampleContentExtension/Info.plist
@@ -23,7 +23,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>UNNotificationExtensionCategory</key>
-			<string>myNotificationCategory</string>
+			<string>sample-extension-category</string>
 			<key>UNNotificationExtensionInitialContentSizeRatio</key>
 			<real>1</real>
 		</dict>
@@ -33,11 +33,7 @@
 		<string>com.apple.usernotifications.content-extension</string>
 		<key>NSExtensionActionWantsFullScreenPresentation</key>
 		<true/>
-		<key>UNNotificationExtensionCategory</key>
-		<string>sample-extension-category</string>
 	</dict>
-	<key>UNNotificationExtensionCategory</key>
-	<string>sample-extension-category</string>
 	<key>CFBundleName</key>
 	<string>SampleContentExtension</string>
 </dict>

--- a/samples/ios-unified/SampleContentExtension/Info.plist
+++ b/samples/ios-unified/SampleContentExtension/Info.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>SampleContentExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.urbanairship.richpush.SampleContentExtension</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>11.0</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>UNNotificationExtensionCategory</key>
+			<string>myNotificationCategory</string>
+			<key>UNNotificationExtensionInitialContentSizeRatio</key>
+			<real>1</real>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.content-extension</string>
+		<key>NSExtensionActionWantsFullScreenPresentation</key>
+		<true/>
+		<key>UNNotificationExtensionCategory</key>
+		<string>sample-extension-category</string>
+	</dict>
+	<key>UNNotificationExtensionCategory</key>
+	<string>sample-extension-category</string>
+	<key>CFBundleName</key>
+	<string>SampleContentExtension</string>
+</dict>
+</plist>

--- a/samples/ios-unified/SampleContentExtension/MainInterface.storyboard
+++ b/samples/ios-unified/SampleContentExtension/MainInterface.storyboard
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106" />
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0" />
+    </dependencies>
+    <scenes>
+        <!--Notification View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" userLabel="Notification View Controller" customClass="NotificationViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0" />
+                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV" />
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37" />
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0"
+                                baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <fontDescription key="fontDescription" type="system" pointSize="17" />
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB" />
+                                <nil key="highlightedColor" />
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.45882353186607361" green="0.74901962280273438" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB" />
+                        <constraints>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="8" symbolic="YES" id="0Q0-KW-PJ6" />
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe" />
+                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU" />
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="8" symbolic="YES" id="mYS-Cv-VNx" />
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout" />
+                    <nil key="simulatedStatusBarMetrics" />
+                    <nil key="simulatedTopBarMetrics" />
+                    <nil key="simulatedBottomBarMetrics" />
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics" />
+                    <size key="freeformSize" width="320" height="37" />
+                    <connections>
+                        <outlet property="label" destination="GcN-lo-r42" id="lpW-cU-7IG" />
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder" />
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/samples/ios-unified/SampleContentExtension/NotificationViewController.cs
+++ b/samples/ios-unified/SampleContentExtension/NotificationViewController.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using UIKit;
+using UserNotifications;
+using UserNotificationsUI;
+using UrbanAirship;
+
+
+namespace SampleContentExtension
+{
+    public partial class NotificationViewController : UAContentExtensionViewController, IUNNotificationContentExtension
+    {
+        protected NotificationViewController(IntPtr handle) : base(handle)
+        {
+            // Note: this .ctor should not contain any initialization logic.
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            // Do any required interface initialization here.
+        }
+
+        public void DidReceiveNotification(UNNotification notification)
+        {
+            label.Text = notification.Request.Content.Body;
+        }
+    }
+}

--- a/samples/ios-unified/SampleContentExtension/NotificationViewController.designer.cs
+++ b/samples/ios-unified/SampleContentExtension/NotificationViewController.designer.cs
@@ -1,0 +1,23 @@
+﻿// WARNING
+//
+// This file has been generated automatically by Visual Studio from the outlets and
+// actions declared in your storyboard file.
+// Manual changes to this file will not be maintained.
+//
+using Foundation;
+using System;
+using System.CodeDom.Compiler;
+
+namespace SampleContentExtension
+{
+    [Register ("NotificationViewController")]
+    partial class NotificationViewController
+    {
+        [Outlet]
+        UIKit.UILabel label { get; set; }
+
+        void ReleaseDesignerOutlets ()
+        {
+        }
+    }
+}

--- a/samples/ios-unified/SampleContentExtension/SampleContentExtension.csproj
+++ b/samples/ios-unified/SampleContentExtension/SampleContentExtension.csproj
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{55571012-1720-4723-AB9D-2C83C2474C6F}</ProjectGuid>
+    <ProjectTypeGuids>{EE2C853D-36AF-4FDB-B1AD-8E90477E2198};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SampleContentExtension</RootNamespace>
+    <AssemblyName>SampleContentExtension</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <IOSDebuggerPort>63990</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
+    <MtouchVerbosity></MtouchVerbosity>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchVerbosity></MtouchVerbosity>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchVerbosity></MtouchVerbosity>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <IOSDebuggerPort>31704</IOSDebuggerPort>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
+    <MtouchVerbosity></MtouchVerbosity>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <InterfaceDefinition Include="MainInterface.storyboard" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NotificationViewController.cs" />
+    <Compile Include="NotificationViewController.designer.cs">
+      <DependentUpon>NotificationViewController.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\AirshipBindings.iOS.NotificationContentExtension\AirshipBindings.iOS.NotificationContentExtension.csproj">
+      <Project>{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}</Project>
+      <Name>AirshipBindings.iOS.NotificationContentExtension</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BundleResource Include="AirshipConfig.plist" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
+</Project>

--- a/samples/ios-unified/SampleContentExtension/SampleContentExtension.sln
+++ b/samples/ios-unified/SampleContentExtension/SampleContentExtension.sln
@@ -1,0 +1,23 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleContentExtension", "SampleContentExtension.csproj", "{55571012-1720-4723-AB9D-2C83C2474C6F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhone.ActiveCfg = Release|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhone.Build.0 = Release|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhone.Build.0 = Debug|iPhone
+	EndGlobalSection
+EndGlobal

--- a/samples/ios-unified/iOSSample.sln
+++ b/samples/ios-unified/iOSSample.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Extende
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.NotificationContentExtension", "..\..\src\AirshipBindings.iOS.NotificationContentExtension\AirshipBindings.iOS.NotificationContentExtension.csproj", "{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleContentExtension", "SampleContentExtension\SampleContentExtension.csproj", "{55571012-1720-4723-AB9D-2C83C2474C6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
@@ -99,5 +101,13 @@ Global
 		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhone.ActiveCfg = Release|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhone.Build.0 = Release|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{55571012-1720-4723-AB9D-2C83C2474C6F}.Debug|iPhone.Build.0 = Debug|iPhone
 	EndGlobalSection
 EndGlobal

--- a/samples/ios-unified/iOSSample.sln
+++ b/samples/ios-unified/iOSSample.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Automat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.ExtendedActions", "..\..\src\AirshipBindings.iOS.ExtendedActions\AirshipBindings.iOS.ExtendedActions.csproj", "{BFFFE653-04CD-4563-BF2D-B6F31349F30D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.NotificationContentExtension", "..\..\src\AirshipBindings.iOS.NotificationContentExtension\AirshipBindings.iOS.NotificationContentExtension.csproj", "{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
@@ -89,5 +91,13 @@ Global
 		{BFFFE653-04CD-4563-BF2D-B6F31349F30D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{BFFFE653-04CD-4563-BF2D-B6F31349F30D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{BFFFE653-04CD-4563-BF2D-B6F31349F30D}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|iPhone.Build.0 = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### What do these changes do?
Adds content extension to xamarin

### Why are these changes necessary?
To clearly demonstrate how to use content extensions on the xamarin platform and to reach sample feature parity with our other platforms

### How did you verify these changes?
Manually tested default content extension UI with push

#### Verification Screenshots:
![content_extension](https://user-images.githubusercontent.com/2199816/76136293-b3168080-5fe4-11ea-8c3b-515a6adeb3d5.PNG)


