### PR TITLE
[MOBILE-1222] .NETStandard/portable attribute support

### DIFF
--- a/UrbanAirship.Android.Core.nuspec
+++ b/UrbanAirship.Android.Core.nuspec
@@ -12,6 +12,10 @@
       <dependencies>
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.AndroidX.Fragment" version="1.1.0" />
+            <dependency id="Xamarin.AndroidX.Core" version="1.0.0" />
+            <dependency id="Xamarin.AndroidX.Annotation" version="1.0.0" />
+            <dependency id="Xamarin.AndroidX.CustomView" version="1.0.0" />
+            <dependency id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.0.0" />
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.Android.Preference.nuspec
+++ b/UrbanAirship.Android.Preference.nuspec
@@ -11,6 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
+            <dependency id="Xamarin.AndroidX.Preference" version="1.0.0"/>
             <dependency id="urbanairship.android.core" version="12.2.0"/>
          </group>
       </dependencies>

--- a/src/AirshipBindings.Android.FCM/packages.config
+++ b/src/AirshipBindings.Android.FCM/packages.config
@@ -29,18 +29,6 @@
   <package id="Xamarin.Android.Support.v4" version="28.0.0.3" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.3" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.3" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Annotation" version="1.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Arch.Core.Common" version="2.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Collection" version="1.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Core" version="1.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Interpolator" version="1.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Lifecycle.Common" version="2.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Lifecycle.Runtime" version="2.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.Migration" version="1.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.MultiDex" version="2.0.1" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.VectorDrawable" version="1.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.VectorDrawable.Animated" version="1.1.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.VersionedParcelable" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Build.Download" version="0.10.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Firebase.Common" version="71.1610.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Firebase.Iid" version="71.1710.0" targetFramework="monoandroid90" />

--- a/src/AirshipBindings.Android.Preference/packages.config
+++ b/src/AirshipBindings.Android.Preference/packages.config
@@ -2,11 +2,15 @@
 <packages>
   <package id="Xamarin.AndroidX.Activity" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Annotation" version="1.1.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.AppCompat" version="1.1.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.AppCompat.Resources" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Arch.Core.Common" version="2.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Arch.Core.Runtime" version="2.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Collection" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Core" version="1.1.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.CursorAdapter" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.CustomView" version="1.0.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.DrawerLayout" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Fragment" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Interpolator" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Lifecycle.Common" version="2.1.0" targetFramework="monoandroid90" />
@@ -16,8 +20,11 @@
   <package id="Xamarin.AndroidX.Loader" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.Migration" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.MultiDex" version="2.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Preference" version="1.1.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.RecyclerView" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.SavedState" version="1.0.0" targetFramework="monoandroid90" />
-  <package id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.0.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.VectorDrawable" version="1.1.0" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.VectorDrawable.Animated" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.VersionedParcelable" version="1.1.0" targetFramework="monoandroid90" />
   <package id="Xamarin.AndroidX.ViewPager" version="1.0.0" targetFramework="monoandroid90" />
 </packages>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/AirshipBindings.NETStandard.Abstractions.csproj
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/AirshipBindings.NETStandard.Abstractions.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Folder Include="Channel\" />
     <Folder Include="Analytics\" />
+    <Folder Include="Attributes\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.CrossPlatform.cs">

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Attributes/AttributeEditor.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Attributes/AttributeEditor.cs
@@ -1,0 +1,146 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace UrbanAirship.NETStandard.Attributes
+{
+    public class AttributeEditor
+    {
+        private List<IAttributeOperation> operations = new List<IAttributeOperation>();
+        private Action<List<IAttributeOperation>> onApply;
+
+        //@cond IGNORE
+        public AttributeEditor(Action<List<IAttributeOperation>> onApply)
+        {
+            this.onApply = onApply;
+        }
+        //@endcond
+
+        /// <summary>
+        /// Sets a string attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, string value)
+        {
+            operations.Add(new SetAttributeOperation<string>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a float attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, float value)
+        {
+            operations.Add(new SetAttributeOperation<float>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a double attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, double value)
+        {
+            operations.Add(new SetAttributeOperation<double>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an int attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, int value)
+        {
+            operations.Add(new SetAttributeOperation<int>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a long attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, long value)
+        {
+            operations.Add(new SetAttributeOperation<long>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Removes an attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        public AttributeEditor RemoveAttribute(string key)
+        {
+            operations.Add(new RemoveAttributeOperation(key));
+            return this;
+        }
+
+        /// <summary>
+        /// Apply the attribute edits.
+        /// </summary>
+        public void Apply()
+        {
+            if (onApply != null)
+            {
+                onApply(operations);
+            }
+        }
+
+        //@cond IGNORE
+
+        /// <summary>
+        /// Interface representing an attribute editor operation.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        public interface IAttributeOperation
+        {
+            OperationType operationType { get; }
+            string key { get; }
+        }
+
+        public class SetAttributeOperation<T> : IAttributeOperation
+        {
+            public OperationType operationType { get; private set; }
+            public string key { get; private set; }
+            public T value { get; private set; }
+
+            internal SetAttributeOperation(string key, T value)
+            {
+                this.operationType = OperationType.SET;
+                this.key = key;
+                this.value = value;
+            }
+        }
+
+        public class RemoveAttributeOperation : IAttributeOperation
+        {
+            public OperationType operationType { get; private set; }
+            public string key { get; private set; }
+
+            internal RemoveAttributeOperation(string key)
+            {
+                this.operationType = OperationType.REMOVE;
+                this.key = key;
+            }
+        }
+
+        public enum OperationType { SET, REMOVE }
+        //@endcond
+    }
+}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -51,5 +51,7 @@ namespace UrbanAirship.NETStandard
         Channel.TagGroupsEditor EditNamedUserTagGroups();
 
         Channel.TagGroupsEditor EditChannelTagGroups();
+        
+        Attributes.AttributeEditor EditAttributes();
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -3,6 +3,7 @@
 */
 
 using System.Collections.Generic;
+using UrbanAirship.NETStandard.Attributes;
 
 namespace UrbanAirship.NETStandard
 {
@@ -168,6 +169,49 @@ namespace UrbanAirship.NETStandard
             {
                 var editor = UAirship.Shared().Channel.EditTagGroups();
                 TagGroupHelper(payload, editor);
+                editor.Apply();
+            });
+        }
+
+        public AttributeEditor EditAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var editor = UAirship.Shared().Channel.EditAttributes();
+
+                foreach (var operation in operations)
+                {
+                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                    {
+                        editor.SetAttribute(stringOperation.key, stringOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                    {
+                        editor.SetAttribute(intOperation.key, intOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                    {
+                        editor.SetAttribute(longOperation.key, longOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                    {
+                        editor.SetAttribute(floatOperation.key, floatOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                    {
+                        editor.SetAttribute(doubleOperation.key, doubleOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                    {
+                        editor.RemoveAttribute(removeOperation.key);
+                    }
+                }
+
                 editor.Apply();
             });
         }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using UrbanAirship.NETStandard.Analytics;
+using UrbanAirship.NETStandard.Attributes;
 
 namespace UrbanAirship.NETStandard
 {
@@ -183,6 +184,49 @@ namespace UrbanAirship.NETStandard
             {
                 TagGroupHelper(payload, false);
                 UAirship.Push().UpdateRegistration();
+            });
+        }
+
+        public AttributeEditor EditAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var mutations = UAAttributeMutations.Mutations();
+
+                foreach (var operation in operations)
+                {
+                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                    {
+                        mutations.SetString(stringOperation.value, stringOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                    {
+                        mutations.SetNumber(intOperation.value, intOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                    {
+                        mutations.SetNumber(longOperation.value, longOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                    {
+                        mutations.SetNumber(floatOperation.value, floatOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                    {
+                        mutations.SetNumber(doubleOperation.value, doubleOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                    {
+                        mutations.RemoveAttribute(removeOperation.key);
+                    }
+                }
+
+                UAirship.Channel().ApplyAttributeMutations(mutations);
             });
         }
 

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -124,6 +124,16 @@ namespace UrbanAirship.NETStandard
         }
 
         /// <summary>
+        /// Edit channel attributes.
+        /// </summary>
+        /// <returns>An <see cref="UrbanAirship.Portable.Attributes.AttributeEditor">AttributeEditor</see>
+        /// for channel attributes.</returns>
+        public Attributes.AttributeEditor EditAttributes()
+        {
+            throw new NotImplementedException(BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
         /// Returns an editor for named user tag groups.
         /// </summary>
         /// <returns>A <see cref="UrbanAirship.NETStandard.Channel.TagGroupsEditor">TagGroupsEditor</see>

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/AirshipBindings.Portable.Abstractions.csproj
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/AirshipBindings.Portable.Abstractions.csproj
@@ -35,10 +35,12 @@
     <Compile Include="..\..\SharedAssemblyInfo.CrossPlatform.cs">
       <Link>Properties\SharedAssemblyInfo.CrossPlatform.cs</Link>
     </Compile>
+    <Compile Include="Attributes\AttributeEditor.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Channel\" />
     <Folder Include="Analytics\" />
+    <Folder Include="Attributes\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/Attributes/AttributeEditor.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/Attributes/AttributeEditor.cs
@@ -1,0 +1,146 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace UrbanAirship.Portable.Attributes
+{
+    public class AttributeEditor
+    {
+        private List<IAttributeOperation> operations = new List<IAttributeOperation>();
+        private Action<List<IAttributeOperation>> onApply;
+
+        //@cond IGNORE
+        public AttributeEditor(Action<List<IAttributeOperation>> onApply)
+        {
+            this.onApply = onApply;
+        }
+        //@endcond
+
+        /// <summary>
+        /// Sets a string attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, string value)
+        {
+            operations.Add(new SetAttributeOperation<string>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a float attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, float value)
+        {
+            operations.Add(new SetAttributeOperation<float>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a double attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, double value)
+        {
+            operations.Add(new SetAttributeOperation<double>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an int attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, int value)
+        {
+            operations.Add(new SetAttributeOperation<int>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets a long attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        /// <param name="value">The attribute value.</param>
+        public AttributeEditor SetAttribute(string key, long value)
+        {
+            operations.Add(new SetAttributeOperation<long>(key, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Removes an attribute.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        public AttributeEditor RemoveAttribute(string key)
+        {
+            operations.Add(new RemoveAttributeOperation(key));
+            return this;
+        }
+
+        /// <summary>
+        /// Apply the attribute edits.
+        /// </summary>
+        public void Apply()
+        {
+            if (onApply != null)
+            {
+                onApply(operations);
+            }
+        }
+
+        //@cond IGNORE
+
+        /// <summary>
+        /// Interface representing an attribute editor operation.
+        /// </summary>
+        /// <returns>The attribute editor.</returns>
+        /// <param name="key">The attribute key.</param>
+        public interface IAttributeOperation
+        {
+            OperationType operationType { get; }
+            string key { get; }
+        }
+
+        public class SetAttributeOperation<T> : IAttributeOperation
+        {
+            public OperationType operationType { get; private set; }
+            public string key { get; private set; }
+            public T value { get; private set; }
+
+            internal SetAttributeOperation(string key, T value)
+            {
+                this.operationType = OperationType.SET;
+                this.key = key;
+                this.value = value;
+            }
+        }
+
+        public class RemoveAttributeOperation : IAttributeOperation
+        {
+            public OperationType operationType { get; private set; }
+            public string key { get; private set; }
+
+            internal RemoveAttributeOperation(string key)
+            {
+                this.operationType = OperationType.REMOVE;
+                this.key = key;
+            }
+        }
+
+        public enum OperationType { SET, REMOVE }
+        //@endcond
+    }
+}

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.Abstractions/IAirship.cs
@@ -51,5 +51,7 @@ namespace UrbanAirship.Portable
         Channel.TagGroupsEditor EditNamedUserTagGroups();
 
         Channel.TagGroupsEditor EditChannelTagGroups();
+
+        Attributes.AttributeEditor EditAttributes();
     }
 }

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.Android/Airship.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.Android/Airship.cs
@@ -3,6 +3,7 @@
 */
 
 using System.Collections.Generic;
+using UrbanAirship.Portable.Attributes;
 
 namespace UrbanAirship.Portable
 {
@@ -168,6 +169,49 @@ namespace UrbanAirship.Portable
             {
                 var editor = UAirship.Shared().Channel.EditTagGroups();
                 TagGroupHelper(payload, editor);
+                editor.Apply();
+            });
+        }
+
+        public AttributeEditor EditAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var editor = UAirship.Shared().Channel.EditAttributes();
+
+                foreach (var operation in operations)
+                {
+                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                    {
+                        editor.SetAttribute(stringOperation.key, stringOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                    {
+                        editor.SetAttribute(intOperation.key, intOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                    {
+                        editor.SetAttribute(longOperation.key, longOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                    {
+                        editor.SetAttribute(floatOperation.key, floatOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                    {
+                        editor.SetAttribute(doubleOperation.key, doubleOperation.value);
+                    }
+
+                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                    {
+                        editor.RemoveAttribute(removeOperation.key);
+                    }
+                }
+
                 editor.Apply();
             });
         }

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable.iOS/Airship.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable.iOS/Airship.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using UrbanAirship.Portable.Analytics;
+using UrbanAirship.Portable.Attributes;
 
 namespace UrbanAirship.Portable
 {
@@ -183,6 +184,49 @@ namespace UrbanAirship.Portable
             {
                 TagGroupHelper(payload, false);
                 UAirship.Push().UpdateRegistration();
+            });
+        }
+
+        public AttributeEditor EditAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var mutations = UAAttributeMutations.Mutations();
+
+                foreach (var operation in operations)
+                {
+                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                    {
+                        mutations.SetString(stringOperation.value, stringOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                    {
+                        mutations.SetNumber(intOperation.value, intOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                    {
+                        mutations.SetNumber(longOperation.value, longOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                    {
+                        mutations.SetNumber(floatOperation.value, floatOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                    {
+                        mutations.SetNumber(doubleOperation.value, doubleOperation.key);
+                    }
+
+                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                    {
+                        mutations.RemoveAttribute(removeOperation.key);
+                    }
+                }
+
+                UAirship.Channel().ApplyAttributeMutations(mutations);
             });
         }
 

--- a/src/AirshipBindings.Portable/AirshipBindings.Portable/Airship.cs
+++ b/src/AirshipBindings.Portable/AirshipBindings.Portable/Airship.cs
@@ -8,137 +8,148 @@ using System.Collections.Generic;
 
 namespace UrbanAirship.Portable
 {
-	public class Airship : IAirship
-	{
-		private static Airship sharedAirship = new Airship();
+    public class Airship : IAirship
+    {
+        private static Airship sharedAirship = new Airship();
 
-		/// <summary>
-		/// Gets the shared UAirship instance.
-		/// </summary>
-		/// <value>The shared UAirship instance.</value>
-		public static Airship Instance
-		{
-			get
-			{
-				return sharedAirship;
-			}
-		}
+        /// <summary>
+        /// Gets the shared UAirship instance.
+        /// </summary>
+        /// <value>The shared UAirship instance.</value>
+        public static Airship Instance
+        {
+            get
+            {
+                return sharedAirship;
+            }
+        }
 
-		/// <summary>
-		/// Indicates whether notifications are enabled.
-		/// </summary>
-		/// <value><c>true</c> if notifications are enabled; otherwise, <c>false</c>.</value>
-		public bool UserNotificationsEnabled
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-			set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Indicates whether notifications are enabled.
+        /// </summary>
+        /// <value><c>true</c> if notifications are enabled; otherwise, <c>false</c>.</value>
+        public bool UserNotificationsEnabled
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Gets the tags currently set for the device.
-		/// </summary>
-		/// <value>The tags.</value>
-		public IEnumerable<string> Tags
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Gets the tags currently set for the device.
+        /// </summary>
+        /// <value>The tags.</value>
+        public IEnumerable<string> Tags
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Get the channel ID for the device.
-		/// </summary>
-		/// <value>The channel identifier.</value>
-		public string ChannelId
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Get the channel ID for the device.
+        /// </summary>
+        /// <value>The channel identifier.</value>
+        public string ChannelId
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Gets or sets the named user ID.
-		/// </summary>
-		/// <value>The named user ID.</value>
-		public string NamedUser
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-			set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Gets or sets the named user ID.
+        /// </summary>
+        /// <value>The named user ID.</value>
+        public string NamedUser
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Edit the device tags.
-		/// </summary>
-		/// <returns>A <see cref="UrbanAirship.Portable.Channel.TagEditor">TagEditor</see>
-                /// for editing device tags.</returns>
-		public Channel.TagEditor EditDeviceTags()
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
+        /// <summary>
+        /// Edit the device tags.
+        /// </summary>
+        /// <returns>A <see cref="UrbanAirship.Portable.Channel.TagEditor">TagEditor</see>
+        /// for editing device tags.</returns>
+        public Channel.TagEditor EditDeviceTags()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
 
-		/// <summary>
-		/// Add a custom event
-		/// </summary>
-		/// <param name="customEvent">The <see cref="UrbanAirship.Portable.Analytics.CustomEvent">CustomEvent</see>
-                /// to add.</param>
-		public void AddCustomEvent(Analytics.CustomEvent customEvent)
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
+        /// <summary>
+        /// Add a custom event
+        /// </summary>
+        /// <param name="customEvent">The <see cref="UrbanAirship.Portable.Analytics.CustomEvent">CustomEvent</see>
+        /// to add.</param>
+        public void AddCustomEvent(Analytics.CustomEvent customEvent)
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
 
-		/// <summary>
-		/// Associate a custom identifier. Previous identifiers will be replaced by the new identifiers
-		/// each time AssociateIdentifier is called. It is a set operation.
-		/// </summary>
-		/// <param name="key">The custom key for the identifier.</param>
-		/// <param name="identifier">The value of the identifier, or `null` to remove the identifier.</param>
-		public void AssociateIdentifier(string key, string identifier)
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
+        /// <summary>
+        /// Associate a custom identifier. Previous identifiers will be replaced by the new identifiers
+        /// each time AssociateIdentifier is called. It is a set operation.
+        /// </summary>
+        /// <param name="key">The custom key for the identifier.</param>
+        /// <param name="identifier">The value of the identifier, or `null` to remove the identifier.</param>
+        public void AssociateIdentifier(string key, string identifier)
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
 
-		/// <summary>
-		/// Displays the message center.
-		/// </summary>
-		public void DisplayMessageCenter()
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
+        /// <summary>
+        /// Displays the message center.
+        /// </summary>
+        public void DisplayMessageCenter()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
 
-		/// <summary>
-		/// Get the message center unread count.
-		/// </summary>
-		/// <value>The message center unread count.</value>
-		public int MessageCenterUnreadCount
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-			private set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Get the message center unread count.
+        /// </summary>
+        /// <value>The message center unread count.</value>
+        public int MessageCenterUnreadCount
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            private set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Get the total count of message center messages.
-		/// </summary>
-		/// <value>The message center count.</value>
-		public int MessageCenterCount
-		{
-			get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-			private set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
-		}
+        /// <summary>
+        /// Get the total count of message center messages.
+        /// </summary>
+        /// <value>The message center count.</value>
+        public int MessageCenterCount
+        {
+            get { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+            private set { throw new NotImplementedException(PCL.BaitWithoutSwitchMessage); }
+        }
 
-		/// <summary>
-		/// Returns an editor for named user tag groups.
-		/// </summary>
-		/// <returns>A <see cref="UrbanAirship.Portable.Channel.TagGroupsEditor">TagGroupsEditor</see>
-                /// for named user tag groups.</returns>
-		public Channel.TagGroupsEditor EditNamedUserTagGroups()
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
+        /// <summary>
+        /// Returns an editor for named user tag groups.
+        /// </summary>
+        /// 
+        /// <returns>A <see cref="UrbanAirship.Portable.Channel.TagGroupsEditor">TagGroupsEditor</see>
+        /// for named user tag groups.</returns>
+        public Channel.TagGroupsEditor EditNamedUserTagGroups()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
 
-		/// <summary>
-		/// Returns an editor for channel tag groups.
-		/// </summary>
-		/// <returns>A <see cref="UrbanAirship.Portable.Channel.TagGroupsEditor">TagGroupsEditor</see>
-                /// for channel tag groups.</returns>
-		public Channel.TagGroupsEditor EditChannelTagGroups()
-		{
-			throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
-		}
-	}
+        /// <summary>
+        /// Returns an editor for channel tag groups.
+        /// </summary>
+        /// <returns>A <see cref="UrbanAirship.Portable.Channel.TagGroupsEditor">TagGroupsEditor</see>
+        /// for channel tag groups.</returns>
+        public Channel.TagGroupsEditor EditChannelTagGroups()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        /// Edit channel attributes.
+        /// </summary>
+        /// <returns>An <see cref="UrbanAirship.Portable.Attributes.AttributeEditor">AttributeEditor</see>
+        /// for channel attributes.</returns>
+        public Attributes.AttributeEditor EditAttributes()
+        {
+            throw new NotImplementedException(PCL.BaitWithoutSwitchMessage);
+        }
+    }
 }

--- a/src/AirshipBindings.iOS.Core/ApiDefinitions.cs
+++ b/src/AirshipBindings.iOS.Core/ApiDefinitions.cs
@@ -767,6 +767,7 @@ namespace UrbanAirship {
         void RemoveAttribute (string attribute);
 
         // + (instancetype)mutations;
+        [Static]
         [Export("mutations")]
         UAAttributeMutations Mutations ();
     }


### PR DESCRIPTION
This adds attribute support to the .NETStandard and Portable libraries. The pattern is similar to the way we ended up implementing CustomEvent properties recently, with generics and exhaustive type checking instead of Object casts, which are illegal in C# in situations that would seem reasonable for Java. Luckily C# has enough syntactic sugar to make it reasonably painless.

On iOS and Android I was able to set attributes from an ad-hoc test app, using locally built nuget packages, and verify they were being bridged properly to the SDK.

Note: VS will complain about missing references and ask you to install a variety of androidx packages by hand unless you change the target SDK version of the forms app to API 29.