### PR TITLE
[MOBILE-1387] Move release to github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,9 @@
-name: CI
+name: Release
 
-on: [pull_request]
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,8 @@ jobs:
         run: ./gradlew build pkg
 
       - name: Publish Nuget
+        env:
+          NUGET_PRODUCTION_API_KEY: ${{ secrets.NUGET_PRODUCTION_API_KEY }}
         run: ./gradlew publishToProduction
 
       - name: Upload Docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  release:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Verify Version
+        run: |
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          PLUGIN_VERSION=$(./gradlew -q getVersion)
+          if [[ $PLUGIN_VERSION = $VERSION ]]; then exit 0 ; else exit 1; fi
+
+      - name: Get Release Notes
+        id: get_release_notes
+        run: |
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          NOTES="$(awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md)"
+          NOTES="${NOTES//'%'/'%25'}"
+          NOTES="${NOTES//$'\n'/'%0A'}"
+          NOTES="${NOTES//$'\r'/'%0D'}"
+          echo ::set-output name=NOTES::"$NOTES"
+
+      - name: Setup GCP
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: "270.0.0"
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Install dependencies
+        run: |
+          brew install doxygen
+          brew install graphviz
+
+      - name: Create google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON" > samples/android/Assets/google-services.json
+
+      - name: Build
+        run: ./gradlew build pkg
+
+      - name: Publish Nuget
+        run: ./gradlew publishToProduction
+
+      - name: Upload Docs
+        run: |
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/xamarin/$VERSION.tar.gz
+
+      - name: Create Github Release
+        uses: actions/create-release@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
+          body: ${{ steps.get_release_notes.outputs.NOTES }}
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,173 +1,112 @@
-# Airship Xamarin Library
+# Airship Xamarin Changelog
 
-This library provides official bindings to the Airship SDK, as well as sample applications for both iOS and Android.
+## Versions 12.0.0 - February 10, 2020
+Major release to support iOS SDK 13.1.
 
-> Note: The library has moved to https://github.com/urbanairship/urbanairship-xamarin
-
-### Release Notes
-
-Versions 12.0.0 (.NETStandard & PCL), 13.1.0 (iOS) - February 10, 2020
-======================================================================
-Major release to support iOS SDK 13.1. Notable changes since the previous (12.1.2) release:
-- Split the iOS SDK into packages. Apps can continue to use a single Airship package in basic integration scenarios,
-but as of SDK 13 it is now possible to create custom integrations by selecting feature packages.
-- Adds support for number attributes & data privacy controls.
-
-This release also fixes the following issues:
-- nupkg installations failing to link with missing symbol errors.
-- .NETStandard and PCL app crashes when adding a custom event (`Airship.Instance.AddCustomEvent();`)
-Apps experiencing either of these issues should update to this version.
-
-Changes
--------
+### Changes
 - Updated iOS SDK to 13.1.0
 - Created new package layout for the new iOS SDK modules:
   - New packages
-    - urbanairship.ios.automation
-    - urbanairship.ios.core
-    - urbanairship.ios.extendedactions
-    - urbanairship.ios.messagecenter
-    - urbanairship.ios.notificationcontentextension
-      - A new content extension for iOS apps.
+    - UrbanAirship.iOS.Automation
+    - UrbanAirship.iOS.Core
+    - UrbanAirship.iOS.ExtendedActions
+    - UrbanAirship.iOS.MessageCenter
+    - UrbanAirship.iOS.NotificationContentExtension
   - Renamed packages
-    - urbanairship.ios.locationkit -> urbanairship.ios.location
-    - urbanairship.ios.appextensions -> urbanairship.ios.notificationserviceextension
-  - urbanairship.ios
-    - A container package with urbanairship.ios.automation, urbanairship.ios.core, urbanairship.ios.extendedactions and urbanairship.ios.messagecenter
-    - Apps can use this to replace the previous urbanairship.ios package.
+    - UrbanAirship.iOS.locationkit -> UrbanAirship.iOS.location
+    - UrbanAirship.iOS.AppExtensions -> UrbanAirship.iOS.N otificationServicEextension
   - Removed undefined constants from iOS bindings.
   - Changes handling of CustomEvent generics in .NETStandard and PCL libraries.
+  - Fixed nupkg installations failing to link with missing symbol errors.
+  - Fixed .NETStandard and PCL app crashes when adding a custom event (Airship.Instance.AddCustomEvent())
 
+## Versions 11.1.0 - December 9, 2019
+Patch release to fix a bug affecting loss of tags on iOS during app migration to iOS SDK 12.0.0.
+This patch release fixes the bug by combining previous tags with tags that have been set since the update
+to iOS SDK 12.0.0. Applications using iOS SDK 12.0.0 should update.
 
-Versions 11.1.0 (.NETStandard & PCL), 12.1.2 (iOS) - December 9, 2019
-=====================================================================
-Patch release to fix a bug affecting loss of tags on iOS during app migration to
-version 12.0.0. This patch release fixes the bug by combining previous tags with
-tags that have been set since the update to 12.0.0. Applications using 12.0.0 
-should update.
-
-Changes
--------
-
+### Changes
 - Update iOS SDK to 12.1.2
 
-Versions 11.0.0 (.NETStandard & PCL), 12.0.0 (iOS) - October 28, 2019
-=====================================================================
+## Versions 11.0.0 - October 28, 2019
 - Update iOS SDK to 12.0.0
 
-Versions 10.1.1 (.NETStandard & PCL, Android), 11.1.0 (iOS) – August 13, 2019
-=============================================================================
+## Versions 10.1.1 – August 13, 2019
 - Update Android SDK to 10.1.1
-
-Changes
--------
 - Patch release to fix direct open reporting for notifications when an activity is resumed from the background
 
-Versions 10.1.0 (.NETStandard & PCL), 11.1.0 (iOS) - July 11, 2019
-===================================================================================
+## Versions 10.1.0  - July 11, 2019
 - Update iOS SDK to 11.1.0
-
-Changes
--------
 - Fixed problem with installation of new iOS LocationKit package.
 
-Versions 10.0.0 (.NETStandard & PCL), 10.0.2 (Android), 11.0.0 (iOS) - July 1, 2019
-===================================================================================
+## Versions 10.0.0 - July 1, 2019
 - Update Android SDK to 10.0.2
 - Update iOS SDK to 11.0.0
-
-Changes
--------
 - Android GCM support has been removed. Please use FCM instead.
 - Android preference support has been moved to the urbanairship.android.preference package.
 - iOS location support has been moved to the urbanairship.ios.locationkit package.
 - Location support has been removed from the PCL and .NETStandard libraries.
 
-Version 9.4.1 - April 19, 2019
-==============================
+## Version 9.4.1 - April 19, 2019
 - Update package references to better support Xamarin 9.x
 - Update Android package dependencies to target API level 28
 - Update Android package to 9.7.1.1. SDK remains at 9.7.1
 - Update iOS SDK to 10.2.2
 
-Version 9.4.0 - March 14, 2019
-==============================
+## Version 9.4.0 - March 14, 2019
 Fixed a security issue within Urban Airship SDK, that could allow trusted URL redirects in certain
-edge cases. Affected package versions include the deprecated urbanairship package 5.0.0 - 5.0.2, the 
-urbanairship.android packages 9.2.0 - 9.5.6, as well as the urbanairship.netstandard and 
-urbanairship.portable packages 9.0.0 - 9.3.3. Apps using any of these should update as soon as possible. 
+edge cases. Affected package versions include the deprecated urbanairship package 5.0.0 - 5.0.2, the
+urbanairship.android packages 9.2.0 - 9.5.6, as well as the urbanairship.netstandard and
+urbanairship.portable packages 9.0.0 - 9.3.3. Apps using any of these should update as soon as possible.
 For more details, please email security@urbanairship.com.
 
 - Update Android SDK to 9.7.2
 - iOS SDK remains at 10.0.3
 
-Version 9.3.3 - November 20, 2018
-=================================
+## Version 9.3.3 - November 20, 2018
 - Update Android SDK to 9.5.6
 - iOS SDK remains at 10.0.3
 
-Version 9.3.2 - November 14, 2018
-=================================
+## Version 9.3.2 - November 14, 2018
 - Update Android SDK to 9.5.5
 - iOS SDK remains at 10.0.3
 
-Version 9.3.1 – November 9, 2018
-================================
+## Version 9.3.1 – November 9, 2018
 - Update iOS SDK to 10.0.3
 - Update Android SDK to 9.5.4
 
-Version 9.3 - October 4, 2018
-=============================
+## Version 9.3 - October 4, 2018
 - Update iOS SDK to 10.0.1
 - Android SDK version is still 9.5.2
 
-Version 9.2 - September 24, 2018
-================================
+## Version 9.2 - September 24, 2018
 - Update iOS SDK to 9.4.0
 - Update Android SDK to 9.5.2
 
-Version 9.1 - July 23, 2018
-===========================
+## Version 9.1 - July 23, 2018
 - Update iOS SDK to 9.3.2
 - Updated Android SDK to 9.4.0
 
-Version 9 - May 22, 2018
-=============================
+## Version 9 - May 22, 2018
 - Updated iOS SDK to 9.1.0
 - Updated Android SDK to 9.2.0.
-
-Note: Android SDK version 9.1.0 introduced support for FCM apis, modular packages, and in-app message design updates. More Android-specific details are available in the [changelog](https://github.com/urbanairship/android-library/blob/9.1.0/CHANGELOG.md). For FCM migration, please follow the [FCM Migration Guide](documentation/migration-guide-fcm.md).
-
-Changes
--------
-- Split urbanairship package into iOS and Android packages. Also moved Android push providers into their own packages. `urbanairship` has been split into:
-
-   - `urbanairship.ios` (iOS)
-   - `urbanairship.ios.appextensions` (iOS Notification Service Extension)
-   - `urbanairship.android.core` (Android core functionality)
-   - `urbanairship.android.adm`  (Android ADM Push Provider)
-   - `urbanairship.android.fcm`  (Android FCM Push Provider)
-   - `urbanairship.android.gcm`  (Android GCM Push Provider)
+- Split urbanairship package into iOS and Android packages. Also moved Android push providers into their own packages. `UrbanAirship` has been split into:
+   - `UrbanAirship.iOS` (iOS)
+   - `UrbanAirship.iOS.appextensions` (iOS Notification Service Extension)
+   - `UrbanAirship.Android.Core` (Android core functionality)
+   - `UrbanAirship.Android.ADM`  (Android ADM Push Provider)
+   - `UrbanAirship.Android.FCM`  (Android FCM Push Provider)
+   - `UrbanAirship.Android.GCM`  (Android GCM Push Provider)
 - Starting with Version 9 of the Xamarin SDK, the version of the native bindings will track the native SDK version contained in that binding. The cross-platform libraries will be independently versioned.
 
-Package | Version
---- | ---
-urbanairship.android.* | 9.2.0
-urbanairship.ios.* | 9.1.0
-urbanairship.netstandard | 9.0.0
-urbanairship.portable | 9.0.0
-
-Version 5.0.2 - April 20, 2018
-==============================
+## Version 5.0.2 - April 20, 2018
 - Added a .NET 2.0 standard library package.
 
-Version 5.0.1 - April 10, 2018
-===============================
+## Version 5.0.1 - April 10, 2018
 - Updated iOS SDK to 9.0.5, and Android SDK to 9.0.6.
 - Fix for undefined symbol errors in iOS bindings when using the mtouch linker.
 
-Version 5.0.0 - March 27, 2018
-==============================
+## Version 5.0.0 - March 27, 2018
 - Updated iOS and Android SDKs to 9.0.4
 
 Note: Aside from SDK interface changes between 8.x and 9.x, iOS bindings have also
@@ -176,149 +115,116 @@ Notably, accessors such as `UAirship.Push` and `UAirship.NamedUser` are now meth
 e.g. `UAirship.Push()` and `UAirship.NamedUser()`. This more closely refelcts
 the structure of the iOS SDK and will help to make bindings more stable moving forward.
 
-Version 4.6.4 - January 12, 2018
-=============================
+## Version 4.6.4 - January 12, 2018
 - Enable use of UAMessageCenterMessageViewController class.
 - Enable use of initWithNibName:bundle: method in UAMessageCenterMessageViewController and UADefaultMessageCenterMessageViewController classes.
 
-Version 4.6.3 - December 12, 2017
-=============================
+## Version 4.6.3 - December 12, 2017
 - Enable use of IUAInAppMessageControllerDelegate protocol.
 
-Version 4.6.2 - December 5, 2017
-=============================
+## Version 4.6.2 - December 5, 2017
 - Enable use of IUAInboxDelegate protocol.
 
-Version 4.6.1 - October 2, 2017
-=============================
+## Version 4.6.1 - October 2, 2017
 - Deep link action had a run-time exception caused by ActionBlock having an incorrect binding.
 - Sample Push Handler was not validating a pointer, causing an NPE
 
-Version 4.6.0 - August 15, 2017
-=============================
+## Version 4.6.0 - August 15, 2017
 - Update Android Urban Airship SDK to 8.8.2.
 - Update iOS Urban Airship SDK to 8.5.2.
 
-Version 4.5.1 - June 28, 2017
-=============================
+## Version 4.5.1 - June 28, 2017
 - Fix iOS Sample for Xamarin component submission.
 
-Version 4.5.0 - June 27, 2017
-=============================
+## Version 4.5.0 - June 27, 2017
 - Update Android Urban Airship SDK to 8.6.0 (Android O support)
 
-Version 4.4.3 - May 23, 2017
-============================
+## Version 4.4.3 - May 23, 2017
 - Update Android Urban Airship SDK to 8.4.2.
 - Update iOS Urban Airship SDK to 8.3.3.
 
-Version 4.4.2 - May 10, 2017
-============================
+## Version 4.4.2 - May 10, 2017
 - Update Android Urban Airship SDK to 8.4.1.
 
-Version 4.4.1 - May 9, 2017
-===========================
+## Version 4.4.1 - May 9, 2017
 - Update iOS Urban Airship SDK to 8.3.1.
 
-Version 4.4.0 - May 4, 2017
-===========================
+## Version 4.4.0 - May 4, 2017
 - Update Android Urban Airship SDK to 8.4.0.
 - Update iOS Urban Airship SDK to 8.3.0.
 
-Version 4.3.0 - April 5, 2017
-=============================
+## Version 4.3.0 - April 5, 2017
 - Update Android Urban Airship SDK to 8.3.2.
 - Add delegate methods to Android bindings.
 
-Version 4.2.2 - March 27, 2017
-==============================
+## Version 4.2.2 - March 27, 2017
 - Fixed dYSM generation build warnings.
 
-Version 4.2.1 - March 22, 2017
-==============================
+## Version 4.2.1 - March 22, 2017
 - Update Android Urban Airship SDK to 8.3.1.
 
-Version 4.2.0 - March 17, 2017
-==============================
+## Version 4.2.0 - March 17, 2017
 - Update Android Urban Airship SDK to 8.3.0.
 - Update iOS bindings with proper memory assignment.
 
-Version 4.1.1 - March 10, 2017
-==============================
+## Version 4.1.1 - March 10, 2017
 - Fixed error on install when trying to use the Urban Airship portable library inside another PCL.
 
-Version 4.1.0 - February 23, 2017
-=================================
+## Version 4.1.0 - February 23, 2017
 - Added an Urban Airship portable class library for use in Xamarin Forms apps.
 
-Version 4.0.1 - January 26, 2017
-================================
+## Version 4.0.1 - January 26, 2017
 - Updated iOS Urban Airship SDK to 8.1.6
 
-Version 4.0.0 - December 16, 2016
-=================================
+## Version 4.0.0 - December 16, 2016
 - Updated iOS SDK to 8.1.4
 - Updated Android SDK to 8.2.2
 - iOS Media Extension is available as a Nuget package
 
-Version 3.1.1 - October 20, 2016
-================================
+## Version 3.1.1 - October 20, 2016
 - Removed the Urban Airship app extension due to deployment issues with older iOS devices. The extension will be restored in a later version of the component.
 
-Version 3.1.0 - October 13, 2016
-================================
+## Version 3.1.0 - October 13, 2016
 - Component is compatible with Urban Airship app extension bindings
 - Fixed build errors when linker is disabled
 
-Version 3.0.0 - October 4, 2016
-===============================
+## Version 3.0.0 - October 4, 2016
 - Updated iOS Urban Airship SDK to 8.0.2
 
-Version 2.2.2 - July 22, 2016
-=============================
+## Version 2.2.2 - July 22, 2016
 - Fixed missing Android bindings for UrbanAirship.Push.Notifications package.
 
-Version 2.2.1 - July 6, 2016
-============================
+## Version 2.2.1 - July 6, 2016
 - Fixed native linking errors for missing UAWalletAction on iOS
 
-Version 2.2 - June 2, 2016
-==========================
+## Version 2.2 - June 2, 2016
 - Updated iOS Urban Airship SDK to 7.2.0
 - Updated Android Urban Airship SDK to 7.1.5
 
-Version 2.1 - May 13, 2016
-==========================
+## Version 2.1 - May 13, 2016
 - Updated iOS Urban Airship SDK to 7.1.2
 - Updated Android Urban Airship SDK to 7.1.3
 - Added NuGet package and shell component support
 
-Version 2.0.5 - April 22, 2016
-==============================
+## Version 2.0.5 - April 22, 2016
  - Added iOS bindings for region events
 
-Version 2.0.4 - April 6, 2016
-==============================
+## Version 2.0.4 - April 6, 2016
  - Fixed missing AndroidManifest entries for the  MessageCenterActivity and MessageActivity.
 
-Version 2.0.3 - March 21, 2016
-==============================
+## Version 2.0.3 - March 21, 2016
  - Fixed Android LocationCallback bindings
 
-Version 2.0.2 - March 1, 2016
-=============================
+## Version 2.0.2 - March 1, 2016
  - Fixed Android linker issues
 
-Version 2.0.1 - Feb 17, 2016
-============================
+## Version 2.0.1 - Feb 17, 2016
  - Fixed Android not registering the GcmPushReceiver
 
-Version 2.0 - Feb 11, 2016
-==========================
+## Version 2.0 - Feb 11, 2016
  - Updated iOS Urban Airship SDK to 7.0.2
  - Updated Android Urban Airship SDK to 7.0.1
  - Added Default Message Center support
 
-Version 1.0 - Nov 23, 2015
-==========================
+## Version 1.0 - Nov 23, 2015
   - Initial release. Binds SDK 6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Airship Xamarin Changelog
 
-## Versions 12.0.0 - February 10, 2020
+## Version 12.0.0 - February 10, 2020
 Major release to support iOS SDK 13.1.
 
 ### Changes
@@ -20,7 +20,7 @@ Major release to support iOS SDK 13.1.
   - Fixed nupkg installations failing to link with missing symbol errors.
   - Fixed .NETStandard and PCL app crashes when adding a custom event (Airship.Instance.AddCustomEvent())
 
-## Versions 11.1.0 - December 9, 2019
+## Version 11.1.0 - December 9, 2019
 Patch release to fix a bug affecting loss of tags on iOS during app migration to iOS SDK 12.0.0.
 This patch release fixes the bug by combining previous tags with tags that have been set since the update
 to iOS SDK 12.0.0. Applications using iOS SDK 12.0.0 should update.
@@ -28,18 +28,18 @@ to iOS SDK 12.0.0. Applications using iOS SDK 12.0.0 should update.
 ### Changes
 - Update iOS SDK to 12.1.2
 
-## Versions 11.0.0 - October 28, 2019
+## Version 11.0.0 - October 28, 2019
 - Update iOS SDK to 12.0.0
 
-## Versions 10.1.1 – August 13, 2019
+## Version 10.1.1 – August 13, 2019
 - Update Android SDK to 10.1.1
 - Patch release to fix direct open reporting for notifications when an activity is resumed from the background
 
-## Versions 10.1.0  - July 11, 2019
+## Version 10.1.0  - July 11, 2019
 - Update iOS SDK to 11.1.0
 - Fixed problem with installation of new iOS LocationKit package.
 
-## Versions 10.0.0 - July 1, 2019
+## Version 10.0.0 - July 1, 2019
 - Update Android SDK to 10.0.2
 - Update iOS SDK to 11.0.0
 - Android GCM support has been removed. Please use FCM instead.
@@ -75,19 +75,19 @@ For more details, please email security@urbanairship.com.
 - Update iOS SDK to 10.0.3
 - Update Android SDK to 9.5.4
 
-## Version 9.3 - October 4, 2018
+## Version 9.3.0 - October 4, 2018
 - Update iOS SDK to 10.0.1
 - Android SDK version is still 9.5.2
 
-## Version 9.2 - September 24, 2018
+## Version 9.2.0 - September 24, 2018
 - Update iOS SDK to 9.4.0
 - Update Android SDK to 9.5.2
 
-## Version 9.1 - July 23, 2018
+## Version 9.1.0 - July 23, 2018
 - Update iOS SDK to 9.3.2
 - Updated Android SDK to 9.4.0
 
-## Version 9 - May 22, 2018
+## Version 9.0.0 - May 22, 2018
 - Updated iOS SDK to 9.1.0
 - Updated Android SDK to 9.2.0.
 - Split urbanairship package into iOS and Android packages. Also moved Android push providers into their own packages. `UrbanAirship` has been split into:
@@ -197,11 +197,11 @@ the structure of the iOS SDK and will help to make bindings more stable moving f
 ## Version 2.2.1 - July 6, 2016
 - Fixed native linking errors for missing UAWalletAction on iOS
 
-## Version 2.2 - June 2, 2016
+## Version 2.2.0 - June 2, 2016
 - Updated iOS Urban Airship SDK to 7.2.0
 - Updated Android Urban Airship SDK to 7.1.5
 
-## Version 2.1 - May 13, 2016
+## Version 2.1.0 - May 13, 2016
 - Updated iOS Urban Airship SDK to 7.1.2
 - Updated Android Urban Airship SDK to 7.1.3
 - Added NuGet package and shell component support
@@ -221,10 +221,10 @@ the structure of the iOS SDK and will help to make bindings more stable moving f
 ## Version 2.0.1 - Feb 17, 2016
  - Fixed Android not registering the GcmPushReceiver
 
-## Version 2.0 - Feb 11, 2016
+## Version 2.0.0 - Feb 11, 2016
  - Updated iOS Urban Airship SDK to 7.0.2
  - Updated Android Urban Airship SDK to 7.0.1
  - Added Default Message Center support
 
-## Version 1.0 - Nov 23, 2015
+## Version 1.0.0 - Nov 23, 2015
   - Initial release. Binds SDK 6.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -240,3 +240,11 @@ build.dependsOn(':docs:build',
     ':src:AirshipBindings.iOS.Location:build',
     ':src:AirshipBindings.iOS.NotificationContentExtension:build',
     ':src:AirshipBindings.iOS.NotificationServiceExtension:build' )
+
+
+
+task getVersion() {
+    doLast {
+        println airshipProperties.crossPlatformVersion
+    }
+}

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -16,4 +16,18 @@ task build {
             include "doxy-boot.js", "header.html", "footer.html"
         }
     }
+    finalizedBy 'packageDocs'
+}
+
+task packageDocs(type: Tar, dependsOn: 'build') {
+    into ('./') {
+        from 'build/html'
+    }
+
+    archiveName = "${airshipProperties.crossPlatformVersion}.tar.gz"
+    compression = Compression.GZIP
+
+    destinationDir file('build')
+    extension 'tar.gz'
+    compression = Compression.GZIP
 }


### PR DESCRIPTION
Cleaned up changelog as well. Going forward we describe our releases in terms of the PCL/NetStandard and only tag those, bumping binding versions is a byproduct of that. To trigger a release, push the version of the netstandard library. This next release I assuming it will be `13.0.0`