### PR TITLE
[update-target-framework-versions] update android target framework settings to 10.0

### DIFF
--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -11,7 +11,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>AirshipBindings.Android.ADM</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <AndroidTlsProvider></AndroidTlsProvider>

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -10,7 +10,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>AirshipBindings.Android.Core</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <AndroidTlsProvider></AndroidTlsProvider>

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AssemblyName>AirshipBindings.Android.FCM</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <AndroidTlsProvider></AndroidTlsProvider>

--- a/src/AirshipBindings.Android.Preference/AirshipBindings.Android.Preference.csproj
+++ b/src/AirshipBindings.Android.Preference/AirshipBindings.Android.Preference.csproj
@@ -13,7 +13,7 @@
     <RootNamespace>UrbanAirship</RootNamespace>
     <AssemblyName>AirshipBindings.Android.Preference</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
   </PropertyGroup>


### PR DESCRIPTION
This is a very minor change, but we should be compiling our bindings with the latest target framework settings, since that's what we're doing for the urbanairship modules they wrap.