### PR TITLE
[MOBILE-1142] Add plugin tracking for iOS

### DIFF
--- a/src/AirshipBindings.iOS.Core/Additions/UAirship.cs
+++ b/src/AirshipBindings.iOS.Core/Additions/UAirship.cs
@@ -1,0 +1,72 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+using System.Reflection;
+using Foundation;
+using ObjCRuntime;
+
+namespace UrbanAirship
+{
+    public partial class UAirship
+    {
+        static UAirship()
+        {
+            NSNotificationCenter.DefaultCenter.AddObserver(new NSString("com.urbanairship.airship_ready"), (notification) =>
+            {
+                // Register Airship Xamarin component
+                Version version = Assembly.GetExecutingAssembly().GetName().Version;
+                UAirship.Analytics().RegisterSDKExtension(UASDKExtension.Xamarin, version.ToString());
+            });
+
+        }
+    }
+
+    // SDK-private enum and method declarations
+    [Native]
+    internal enum UASDKExtension : ulong
+    {
+        Cordova = 0,
+        Xamarin = 1,
+        Unity = 2,
+        Flutter = 3,
+        ReactNative = 4
+    }
+
+    public unsafe partial class UAAnalytics : UAComponent
+    {
+        [Export("registerSDKExtension:version:")]
+        [BindingImpl(BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+        internal virtual void RegisterSDKExtension(UASDKExtension extension, string version)
+        {
+            if (version == null)
+                throw new ArgumentNullException("version");
+            var nsversion = NSString.CreateNative(version);
+
+            if (IsDirectBinding)
+            {
+                if (IntPtr.Size == 8)
+                {
+                    global::ApiDefinitions.Messaging.void_objc_msgSend_UInt64_IntPtr(this.Handle, Selector.GetHandle("registerSDKExtension:version:"), (UInt64)extension, nsversion);
+                }
+                else
+                {
+                    global::ApiDefinitions.Messaging.void_objc_msgSend_UInt32_IntPtr(this.Handle, Selector.GetHandle("registerSDKExtension:version:"), (UInt32)extension, nsversion);
+                }
+            }
+            else
+            {
+                if (IntPtr.Size == 8)
+                {
+                    global::ApiDefinitions.Messaging.void_objc_msgSendSuper_UInt64_IntPtr(this.SuperHandle, Selector.GetHandle("registerSDKExtension:version:"), (UInt64)extension, nsversion);
+                }
+                else
+                {
+                    global::ApiDefinitions.Messaging.void_objc_msgSendSuper_UInt32_IntPtr(this.SuperHandle, Selector.GetHandle("registerSDKExtension:version:"), (UInt32)extension, nsversion);
+                }
+            }
+            NSString.ReleaseNative(nsversion);
+        }
+    }
+}

--- a/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
+++ b/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\SharedAssemblyInfo.iOS.cs">
       <Link>Properties\SharedAssemblyInfo.iOS.cs</Link>
     </Compile>
+    <Compile Include="Additions\UAirship.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
@@ -53,6 +54,9 @@
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
     </NativeReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Additions\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>


### PR DESCRIPTION
### What do these changes do?
Add plugin tracking for iOS to Xamarin component. Now Xamarin iOS apps will report something like `"X-UA-Frameworks" = "xamarin:13.1.1.0";` to analytics when they run.

### Why are these changes necessary?
Better understanding of the usage of our Xamarin components.

### How did you verify these changes?
Ran on device with trace-level logging to see headers uploaded to Analytics.

### Anything else a reviewer should know?
The `registerSDKExtension:version:` method and `UASDKExtension` enum are not exposed through our API bindings. They are labelled `:nodoc:` in the iOS SDK and Xamboni ignores `:nodoc:` items, assuming they are SDK-private. I temporarily exposed the two and ran Xamboni to generate the appropriate bindings, which I then copied into `UAirship.cs`, my class that actually registers the sdk extension. It's kinda ugly, but works just fine. If we choose to expose the method and enum in the future, the `AirshipBindings.iOS.Core` build will fail, but all we have to do is remove the bindings I copied into `UAirship.cs`. 