### PR TITLE
[fix-target-framework-dependencies] fix target framework dependencies

### DIFF
--- a/UrbanAirship.Android.ADM.nuspec
+++ b/UrbanAirship.Android.ADM.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="urbanairship.android.core" version="12.2.0"/>
          </group>
       </dependencies>

--- a/UrbanAirship.Android.Accengage.nuspec
+++ b/UrbanAirship.Android.Accengage.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="urbanairship.android.core" version="12.2.0"/>  
          </group>
       </dependencies>

--- a/UrbanAirship.Android.Core.nuspec
+++ b/UrbanAirship.Android.Core.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.AndroidX.Fragment" version="1.1.0" />
             <dependency id="Xamarin.AndroidX.Core" version="1.0.0" />
             <dependency id="Xamarin.AndroidX.Annotation" version="1.0.0" />

--- a/UrbanAirship.Android.FCM.nuspec
+++ b/UrbanAirship.Android.FCM.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.Firebase.Messaging" version="71.1740.0" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="71.1610.0" />
             <dependency id="urbanairship.android.core" version="12.2.0"/>

--- a/UrbanAirship.Android.Preference.nuspec
+++ b/UrbanAirship.Android.Preference.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.AndroidX.Preference" version="1.0.0"/>
             <dependency id="urbanairship.android.core" version="12.2.0"/>
          </group>

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -10,11 +10,14 @@
       <description>A .NET Standard Library for the Airship SDK.</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+         <group targetFramework=".NETStandard2.0">
+         </group>
+
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="urbanairship.android.core" version="12.2.0"/>
          </group>
 
-         <group targetFramework="Xamarin.iOS">
+         <group targetFramework="Xamarin.iOS1.0">
             <dependency id="urbanairship.ios.core" version="13.1.1"/>
             <dependency id="urbanairship.ios.automation" version="13.1.1"/>
             <dependency id="urbanairship.ios.extendedactions" version="13.1.1"/>

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -10,11 +10,14 @@
       <description>A portable client library for the Airship SDK.</description>
 
       <dependencies>
-         <group targetFramework="MonoAndroid">
+	 <group targetFramework=".NETPortable0.0-Profile259">
+         </group>
+
+         <group targetFramework="MonoAndroid4.1">
             <dependency id="urbanairship.android.core" version="12.2.0"/>
          </group>
 
-         <group targetFramework="Xamarin.iOS">
+         <group targetFramework="Xamarin.iOS1.0">
             <dependency id="urbanairship.ios.core" version="13.1.1"/>
             <dependency id="urbanairship.ios.automation" version="13.1.1"/>
             <dependency id="urbanairship.ios.extendedactions" version="13.1.1"/>

--- a/UrbanAirship.iOS.Accengage.nuspec
+++ b/UrbanAirship.iOS.Accengage.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Accengage support for Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.Automation.nuspec
+++ b/UrbanAirship.iOS.Automation.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Automation support for Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.Core.nuspec
+++ b/UrbanAirship.iOS.Core.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Core of Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.ExtendedActions.nuspec
+++ b/UrbanAirship.iOS.ExtendedActions.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Extended actions support for Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.Location.nuspec
+++ b/UrbanAirship.iOS.Location.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Location support for Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.MessageCenter.nuspec
+++ b/UrbanAirship.iOS.MessageCenter.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Message center support for Airship SDK</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.NotificationContentExtension.nuspec
+++ b/UrbanAirship.iOS.NotificationContentExtension.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Notification content extension support for iOS</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.NotificationServiceExtension.nuspec
+++ b/UrbanAirship.iOS.NotificationServiceExtension.nuspec
@@ -8,6 +8,9 @@
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
       <description>Notification service extension support for iOS</description>
+      <dependencies>
+        <group targetFramework="Xamarin.iOS1.0" />
+      </dependencies>
    </metadata>
 
    <files>

--- a/UrbanAirship.iOS.nuspec
+++ b/UrbanAirship.iOS.nuspec
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
 
       <dependencies>
-         <group targetFramework="Xamarin.iOS">
+         <group>
             <dependency id="urbanairship.ios.core" version="13.1.1"/>
             <dependency id="urbanairship.ios.automation" version="13.1.1"/>
             <dependency id="urbanairship.ios.extendedactions" version="13.1.1"/>


### PR DESCRIPTION
There were a variety of warnings when running the packaging script, such as:

Attempting to build package from 'UrbanAirship.Android.Core.nuspec'.
Successfully created package '/Users/brian.batchelder/source/mobile-1142-urbanairship-xamarin-Xamarin-add-plugin-tracking-on-iOS/build/urbanairship.android.core.12.2.0.nupkg'.
WARNING: NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below:
- Add lib or ref assemblies for the monoandroid target framework
WARNING: NU5130: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder have compatible matches, but not exact matches in the other location. Unless intentional, consult the list of actions below:
- Add a dependency group for MonoAndroid4.1 to the nuspec

These are complaints that the target frameworks the DLLs are getting built against aren't specified as group dependencies in the nuspec. The [docs](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) on the warning mention that this can cause subtle runtime errors, and confusion for software that consumes the nuspec.

I did what the warning logs asked, and added the recommended dependency info, as well as removed it for the umbrella iOS nuspec, which doesn't actually create a DLL and thus doesn't need one.

Tested by running the packaging script, and verifying that packages are successfully built without any warnings.
