### PR TITLE
[MOBILE-1486] MessagePage

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/AirshipBindings.NETStandard.Abstractions.csproj
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/AirshipBindings.NETStandard.Abstractions.csproj
@@ -12,10 +12,14 @@
     <Folder Include="Channel\" />
     <Folder Include="Analytics\" />
     <Folder Include="Attributes\" />
+    <Folder Include="Message Center\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.CrossPlatform.cs">
       <Link>Properties\SharedAssemblyInfo.CrossPlatform.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
   </ItemGroup>
 </Project>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Message Center/MessagePage.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Message Center/MessagePage.cs
@@ -1,0 +1,153 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+
+using Xamarin.Forms;
+
+namespace UrbanAirship.NETStandard.MessageCenter
+{
+    /// <summary>
+    /// ContentPage used for displaying Message Center Messages.
+    /// </summary>
+    public partial class MessagePage : ContentPage
+    {
+        /// <summary>
+        /// Gets and sets the message ID.
+        /// </summary>
+        /// <value>The message ID.</value>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// Event handler invoked when the message has loaded.
+        /// </summary>
+        public event EventHandler<MessageLoadedEventArgs> Loaded;
+
+        /// <summary>
+        /// Event handler invoked whe  the message load fails.
+        /// </summary>
+        public event EventHandler<MessageLoadFailedEventArgs> LoadFailed;
+
+        /// <summary>
+        /// Event handler invoked when the message is closed.
+        /// </summary>
+        public event EventHandler<MessageClosedEventArgs> Closed;
+
+        /// <summary>
+        /// MessagePage constructor.
+        /// </summary>
+        public MessagePage()
+        {
+        }
+
+        //@cond IGNORE
+        public void OnRendererLoaded(string messageId)
+        {
+            Loaded?.Invoke(this, new MessageLoadedEventArgs(messageId));
+        }
+
+        public void OnRendererLoadFailed(string messageId, bool retriable, MessageFailureStatus status)
+        {
+            LoadFailed?.Invoke(this, new MessageLoadFailedEventArgs(messageId, retriable, status));
+        }
+
+        public void OnRendererClosed(string messageId)
+        {
+            Closed?.Invoke(this, new MessageClosedEventArgs(messageId));
+        }
+        //@endcond
+    }
+
+    /// <summary>
+    /// Event handler invoked when the message is closed.
+    /// </summary>
+    public enum MessageFailureStatus
+    {
+        /// <summary>
+        /// The message is unavailable.
+        /// </summary>
+        Unavailable,
+
+        /// <summary>
+        /// The message list could not be fetched.
+        /// </summary>
+        FetchFailed,
+
+        /// <summary>
+        /// The message failed to load.
+        /// </summary>
+        LoadFailed
+    }
+
+    /// <summary>
+    /// Arguments for the LoadFailed event.
+    /// </summary>
+    public class MessageLoadFailedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the retriable value.
+        /// </summary>
+        /// <value>Whether the message load is retriable.</value>
+        public bool Retriable { get; private set; }
+
+        /// <summary>
+        /// Gets the message failure status.
+        /// </summary>
+        /// <value>The message failure status</value>
+        public MessageFailureStatus FailureStatus { get; private set; }
+
+        /// <summary>
+        /// Gets the message ID.
+        /// </summary>
+        /// <value>The message ID.</value>
+        public string MessageId { get; private set; }
+
+        //@cond IGNORE
+        public MessageLoadFailedEventArgs(string messageId, bool retriable, MessageFailureStatus status)
+        {
+            MessageId = messageId;
+            Retriable = retriable;
+            FailureStatus = status;
+        }
+        //@endcond
+    }
+
+    /// <summary>
+    /// Arguments for the Loaded event.
+    /// </summary>
+    public class MessageLoadedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the message ID.
+        /// </summary>
+        /// <value>The message ID.</value>
+        public string MessageId { get; private set; }
+
+        //@cond IGNORE
+        public MessageLoadedEventArgs(string messageId)
+        {
+            MessageId = messageId;
+        }
+        //@endcond
+    }
+
+    /// <summary>
+    /// Arguments for the Closed event.
+    /// </summary>
+    public class MessageClosedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the message ID.
+        /// </summary>
+        /// <value>The message ID.</value>
+        public string MessageId { get; private set; }
+
+        //@cond IGNORE
+        public MessageClosedEventArgs(string messageId)
+        {
+            MessageId = messageId;
+        }
+        //@endcond
+    }
+}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Message Center/MessagePage.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/Message Center/MessagePage.cs
@@ -13,11 +13,29 @@ namespace UrbanAirship.NETStandard.MessageCenter
     /// </summary>
     public partial class MessagePage : ContentPage
     {
+        private string messageId;
+
+        public static readonly BindableProperty MessageIdProperty = BindableProperty.Create(
+            propertyName: "MessageId",
+            returnType: typeof(string),
+            declaringType: typeof(MessagePage),
+            defaultValue: null,
+            defaultBindingMode: BindingMode.OneWay,
+            propertyChanged: null);
+
         /// <summary>
         /// Gets and sets the message ID.
         /// </summary>
         /// <value>The message ID.</value>
-        public string MessageId { get; set; }
+        public string MessageId {
+            get { return (string)GetValue(MessageIdProperty); }
+            set { SetValue(MessageIdProperty, value); }
+        }
+
+        /// <summary>
+        /// Event handler invoked when the message starts loading.
+        /// </summary>
+        public event EventHandler<MessageLoadStartedEventArgs> LoadStarted;
 
         /// <summary>
         /// Event handler invoked when the message has loaded.
@@ -25,7 +43,7 @@ namespace UrbanAirship.NETStandard.MessageCenter
         public event EventHandler<MessageLoadedEventArgs> Loaded;
 
         /// <summary>
-        /// Event handler invoked whe  the message load fails.
+        /// Event handler invoked when the message load fails.
         /// </summary>
         public event EventHandler<MessageLoadFailedEventArgs> LoadFailed;
 
@@ -37,11 +55,14 @@ namespace UrbanAirship.NETStandard.MessageCenter
         /// <summary>
         /// MessagePage constructor.
         /// </summary>
-        public MessagePage()
-        {
-        }
+        public MessagePage() { }
 
         //@cond IGNORE
+        public void OnRendererLoadStarted(string messageId)
+        {
+            LoadStarted?.Invoke(this, new MessageLoadStartedEventArgs(messageId));
+        }
+
         public void OnRendererLoaded(string messageId)
         {
             Loaded?.Invoke(this, new MessageLoadedEventArgs(messageId));
@@ -78,6 +99,25 @@ namespace UrbanAirship.NETStandard.MessageCenter
         /// The message failed to load.
         /// </summary>
         LoadFailed
+    }
+
+    /// <summary>
+    /// Arguments for the LoadStarted event.
+    /// </summary>
+    public class MessageLoadStartedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets the message ID.
+        /// </summary>
+        /// <value>The message ID.</value>
+        public string MessageId { get; private set; }
+
+        //@cond IGNORE
+        public MessageLoadStartedEventArgs(string messageId)
+        {
+            MessageId = messageId;
+        }
+        //@endcond
     }
 
     /// <summary>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/AirshipBindings.NETStandard.Android.csproj
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/AirshipBindings.NETStandard.Android.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Forms.4.6.0.726\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.4.6.0.726\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AirshipBindings.NETStandard</RootNamespace>
     <AssemblyName>AirshipBindings.NETStandard</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
@@ -40,6 +41,94 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Xamarin.Android.Support.Print">
+      <HintPath>..\packages\Xamarin.Android.Support.Print.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Print.dll</HintPath>
+    </Reference>
+    <Reference Include="Java.Interop" />
+    <Reference Include="Xamarin.Android.Support.v7.CardView">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.VersionedParcelable">
+      <HintPath>..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.VersionedParcelable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Compat.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.AsyncLayoutInflater">
+      <HintPath>..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.CustomView">
+      <HintPath>..\packages\Xamarin.Android.Support.CustomView.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.CustomView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.CoordinaterLayout">
+      <HintPath>..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.DrawerLayout">
+      <HintPath>..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.DrawerLayout.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Loader">
+      <HintPath>..\packages\Xamarin.Android.Support.Loader.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Loader.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.Utils">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Core.Utils.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Media.Compat">
+      <HintPath>..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Media.Compat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.SlidingPaneLayout">
+      <HintPath>..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.SwipeRefreshLayout">
+      <HintPath>..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.ViewPager">
+      <HintPath>..\packages\Xamarin.Android.Support.ViewPager.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.ViewPager.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Core.UI">
+      <HintPath>..\packages\Xamarin.Android.Support.Core.UI.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Core.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable">
+      <HintPath>..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.CustomTabs">
+      <HintPath>..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.CustomTabs.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Fragment">
+      <HintPath>..\packages\Xamarin.Android.Support.Fragment.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Fragment.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Transition">
+      <HintPath>..\packages\Xamarin.Android.Support.Transition.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Transition.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>..\packages\Xamarin.Android.Support.v4.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.AppCompat">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.RecyclerView">
+      <HintPath>..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Design">
+      <HintPath>..\packages\Xamarin.Android.Support.Design.28.0.0.3\lib\monoandroid90\Xamarin.Android.Support.Design.dll</HintPath>
+    </Reference>
+    <Reference Include="FormsViewGroup">
+      <HintPath>..\packages\Xamarin.Forms.4.6.0.726\lib\MonoAndroid90\FormsViewGroup.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.4.6.0.726\lib\MonoAndroid90\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.Android">
+      <HintPath>..\packages\Xamarin.Forms.4.6.0.726\lib\MonoAndroid90\Xamarin.Forms.Platform.Android.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.4.6.0.726\lib\MonoAndroid90\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.4.6.0.726\lib\MonoAndroid90\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />
@@ -48,9 +137,13 @@
     <Compile Include="..\..\SharedAssemblyInfo.CrossPlatform.cs">
       <Link>Properties\SharedAssemblyInfo.CrossPlatform.cs</Link>
     </Compile>
+    <Compile Include="MessagePageRenderer.cs">
+      <IncludeInPackage>false</IncludeInPackage>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\Strings.xml" />
@@ -66,4 +159,42 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Android.Support.Annotations.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Annotations.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Annotations.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Annotations.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Core.Common.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Common.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Core.Common.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Core.Runtime.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Core.Runtime.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Common.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Common.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.Core.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.Core.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.LiveData.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.LiveData.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Runtime.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Runtime.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.ViewModel.1.1.1.3\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.ViewModel.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Collections.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Collections.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Collections.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Collections.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CursorAdapter.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CursorAdapter.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.DocumentFile.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DocumentFile.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.DocumentFile.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Interpolator.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Interpolator.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Interpolator.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.LocalBroadcastManager.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.LocalBroadcastManager.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Print.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Print.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Print.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Print.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.CardView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.CardView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.VersionedParcelable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.VersionedParcelable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Compat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Compat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets" Condition="Exists('..\packages\Xamarin.Android.Support.AsyncLayoutInflater.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.AsyncLayoutInflater.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.CustomView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CustomView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CustomView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CoordinaterLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CoordinaterLayout.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.DrawerLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.DrawerLayout.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Loader.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Loader.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Loader.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Loader.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.Utils.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Core.Utils.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Media.Compat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Media.Compat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SlidingPaneLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.SlidingPaneLayout.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets" Condition="Exists('..\packages\Xamarin.Android.Support.SwipeRefreshLayout.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.SwipeRefreshLayout.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.ViewPager.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets" Condition="Exists('..\packages\Xamarin.Android.Support.ViewPager.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.ViewPager.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Core.UI.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Core.UI.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Core.UI.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets" Condition="Exists('..\packages\Xamarin.Android.Support.CustomTabs.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.CustomTabs.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Fragment.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Fragment.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Fragment.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Fragment.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Transition.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Transition.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Transition.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Transition.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v4.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v4.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v4.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v4.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.AppCompat.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.AppCompat.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.Android.Support.v7.RecyclerView.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.v7.RecyclerView.targets')" />
+  <Import Project="..\packages\Xamarin.Android.Support.Design.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Design.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Design.28.0.0.3\build\monoandroid90\Xamarin.Android.Support.Design.targets')" />
+  <Import Project="..\packages\Xamarin.Forms.4.6.0.726\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.4.6.0.726\build\Xamarin.Forms.targets')" />
 </Project>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/MessagePageRenderer.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/MessagePageRenderer.cs
@@ -1,0 +1,166 @@
+﻿using Android.Content;
+using Android.Runtime;
+using Android.Views;
+using Android.Webkit;
+using Android.Widget;
+using UrbanAirship.NETStandard.MessageCenter;
+using UrbanAirship.RichPush;
+using UrbanAirship.Widget;
+using Xamarin.Forms.Platform.Android;
+
+namespace UrbanAirship.NETStandard.Android
+{
+    public class MessagePageRenderer : PageRenderer, RichPushInbox.IFetchMessagesCallback
+    {
+        private class MessageWebViewClient : UAWebViewClient
+        {
+            private MessagePageRenderer renderer;
+            private bool error = false;
+
+            public MessageWebViewClient(MessagePageRenderer messagePageRenderer)
+            {
+                renderer = messagePageRenderer;
+            }
+
+            public override void OnPageFinished(WebView view, string url)
+            {
+                base.OnPageFinished(view, url);
+
+                if (renderer.message == null)
+                {
+                    return;
+                }
+
+                if (error)
+                {
+                    renderer.messagePage.OnRendererLoadFailed(renderer.message.MessageId, false, MessageFailureStatus.LoadFailed);
+                    return;
+                }
+
+                renderer.message.MarkRead();
+                renderer.messagePage.OnRendererLoaded(renderer.message.MessageId);
+            }
+
+#pragma warning disable CS0672 // Member overrides obsolete member
+            public override void OnReceivedError(WebView view, [GeneratedEnum] ClientError errorCode, string description, string failingUrl)
+#pragma warning restore CS0672 // Member overrides obsolete member
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                base.OnReceivedError(view, errorCode, description, failingUrl);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                if (renderer.message != null && failingUrl != null && failingUrl.Equals(renderer.message.MessageBodyUrl))
+                {
+                    error = true;
+                }
+            }
+
+            public override void OnClose(WebView webView)
+            {
+                base.OnClose(webView);
+                if (renderer.message != null)
+                {
+                    renderer.messagePage.OnRendererClosed(renderer.message.MessageId);
+                }
+            }
+        }
+
+        private RichPushMessage message;
+        private ICancelable fetchMessageRequest;
+        private UAWebView webView;
+        private MessagePage messagePage;
+        private WebViewClient webViewClient;
+        private string messageId;
+        private FrameLayout nativeView;
+
+        public MessagePageRenderer(Context context) : base(context)
+        {
+            webView = new UAWebView(Context);
+            webViewClient = new MessageWebViewClient(this);
+
+            var fl = new FrameLayout(Context);
+            fl.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
+
+            fl.AddView(webView);
+
+            webView.SetWebViewClient(webViewClient);
+            AddView(fl);
+
+            nativeView = fl;
+        }
+
+        public void LoadMessage(string messageId)
+        {
+            if (fetchMessageRequest != null)
+            {
+                fetchMessageRequest.Cancel();
+            }
+
+            message = null;
+            StartLoading(messageId);
+        }
+
+        private void StartLoading(string messageId)
+        {
+            this.message = UAirship.Shared().Inbox.GetMessage(messageId);
+            if (message == null)
+            {
+                fetchMessageRequest = UAirship.Shared().Inbox.FetchMessages(this);
+            }
+            else
+            {
+                if (message.IsExpired)
+                {
+                    messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
+                    return;
+                }
+            }
+            webView.LoadRichPushMessage(message);
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Xamarin.Forms.Page> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null || Element == null)
+            {
+                return;
+            }
+
+            messagePage = e.NewElement as MessagePage;
+            messageId = messagePage.MessageId;
+
+            LoadMessage(messageId);
+        }
+
+        protected override void OnLayout(bool changed, int l, int t, int r, int b)
+        {
+            base.OnLayout(changed, l, t, r, b);
+
+            if (nativeView != null)
+            {
+                var msw = MeasureSpec.MakeMeasureSpec(r - l, MeasureSpecMode.Exactly);
+                var msh = MeasureSpec.MakeMeasureSpec(b - t, MeasureSpecMode.Exactly);
+
+                nativeView.Measure(msw, msh);
+                nativeView.Layout(0, 0, r - l, b - t);
+            }
+        }
+
+        void RichPushInbox.IFetchMessagesCallback.OnFinished(bool success)
+        {
+            message = UAirship.Shared().Inbox.GetMessage(messageId);
+            if (!success)
+            {
+                messagePage.OnRendererLoadFailed(messageId, true, MessageFailureStatus.FetchFailed);
+                return;
+            }
+            else if (message == null || message.IsExpired)
+            {
+                messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
+                return;
+            }
+            webView.LoadRichPushMessage(message);
+        }
+    }
+}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/MessagePageRenderer.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/MessagePageRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Android.Content;
+﻿using System.ComponentModel;
+using Android.Content;
 using Android.Runtime;
 using Android.Views;
 using Android.Webkit;
@@ -114,8 +115,10 @@ namespace UrbanAirship.NETStandard.Android
                     messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
                     return;
                 }
+
+                webView.LoadRichPushMessage(message);
+                messagePage.OnRendererLoadStarted(messageId);
             }
-            webView.LoadRichPushMessage(message);
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Xamarin.Forms.Page> e)
@@ -130,7 +133,22 @@ namespace UrbanAirship.NETStandard.Android
             messagePage = e.NewElement as MessagePage;
             messageId = messagePage.MessageId;
 
-            LoadMessage(messageId);
+            if (messageId != null)
+            {
+                LoadMessage(messageId);
+            }
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName.Equals(MessagePage.MessageIdProperty.PropertyName))
+            {
+                messageId = messagePage.MessageId;
+                if (messageId != null)
+                {
+                    LoadMessage(messageId);
+                }
+            }
         }
 
         protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -160,7 +178,9 @@ namespace UrbanAirship.NETStandard.Android
                 messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
                 return;
             }
+
             webView.LoadRichPushMessage(message);
+            messagePage.OnRendererLoadStarted(messageId);
         }
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Properties/AssemblyInfo.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
-// Information about this assembly is defined by the following attributes. 
-// Change them to the values specific to your project.
+using UrbanAirship.NETStandard.MessageCenter;
+using Xamarin.Forms;
 
 [assembly: AssemblyTitle("AirshipBindings.NETStandard.Android")]
+[assembly: ExportRenderer(typeof(MessagePage), typeof(UrbanAirship.NETStandard.Android.MessagePageRenderer))]
+

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Resources/Resource.designer.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Resources/Resource.designer.cs
@@ -28,10 +28,64 @@ namespace AirshipBindings.NETStandard
 		{
 			
 			// aapt resource value: 0x7F010000
-			public static int ua_iam_fade_in = 2130771968;
+			public static int abc_fade_in = 2130771968;
 			
 			// aapt resource value: 0x7F010001
-			public static int ua_iam_fade_out = 2130771969;
+			public static int abc_fade_out = 2130771969;
+			
+			// aapt resource value: 0x7F010002
+			public static int abc_grow_fade_in_from_bottom = 2130771970;
+			
+			// aapt resource value: 0x7F010003
+			public static int abc_popup_enter = 2130771971;
+			
+			// aapt resource value: 0x7F010004
+			public static int abc_popup_exit = 2130771972;
+			
+			// aapt resource value: 0x7F010005
+			public static int abc_shrink_fade_out_from_bottom = 2130771973;
+			
+			// aapt resource value: 0x7F010006
+			public static int abc_slide_in_bottom = 2130771974;
+			
+			// aapt resource value: 0x7F010007
+			public static int abc_slide_in_top = 2130771975;
+			
+			// aapt resource value: 0x7F010008
+			public static int abc_slide_out_bottom = 2130771976;
+			
+			// aapt resource value: 0x7F010009
+			public static int abc_slide_out_top = 2130771977;
+			
+			// aapt resource value: 0x7F01000A
+			public static int abc_tooltip_enter = 2130771978;
+			
+			// aapt resource value: 0x7F01000B
+			public static int abc_tooltip_exit = 2130771979;
+			
+			// aapt resource value: 0x7F01000C
+			public static int design_bottom_sheet_slide_in = 2130771980;
+			
+			// aapt resource value: 0x7F01000D
+			public static int design_bottom_sheet_slide_out = 2130771981;
+			
+			// aapt resource value: 0x7F01000E
+			public static int design_snackbar_in = 2130771982;
+			
+			// aapt resource value: 0x7F01000F
+			public static int design_snackbar_out = 2130771983;
+			
+			// aapt resource value: 0x7F010010
+			public static int EnterFromLeft = 2130771984;
+			
+			// aapt resource value: 0x7F010011
+			public static int EnterFromRight = 2130771985;
+			
+			// aapt resource value: 0x7F010012
+			public static int ExitToLeft = 2130771986;
+			
+			// aapt resource value: 0x7F010013
+			public static int ExitToRight = 2130771987;
 			
 			static Animation()
 			{
@@ -47,16 +101,34 @@ namespace AirshipBindings.NETStandard
 		{
 			
 			// aapt resource value: 0x7F020000
-			public static int ua_iam_slide_in_bottom = 2130837504;
+			public static int design_appbar_state_list_animator = 2130837504;
 			
 			// aapt resource value: 0x7F020001
-			public static int ua_iam_slide_in_top = 2130837505;
+			public static int design_fab_hide_motion_spec = 2130837505;
 			
 			// aapt resource value: 0x7F020002
-			public static int ua_iam_slide_out_bottom = 2130837506;
+			public static int design_fab_show_motion_spec = 2130837506;
 			
 			// aapt resource value: 0x7F020003
-			public static int ua_iam_slide_out_top = 2130837507;
+			public static int mtrl_btn_state_list_anim = 2130837507;
+			
+			// aapt resource value: 0x7F020004
+			public static int mtrl_btn_unelevated_state_list_anim = 2130837508;
+			
+			// aapt resource value: 0x7F020005
+			public static int mtrl_chip_state_list_anim = 2130837509;
+			
+			// aapt resource value: 0x7F020006
+			public static int mtrl_fab_hide_motion_spec = 2130837510;
+			
+			// aapt resource value: 0x7F020007
+			public static int mtrl_fab_show_motion_spec = 2130837511;
+			
+			// aapt resource value: 0x7F020008
+			public static int mtrl_fab_transformation_sheet_collapse_spec = 2130837512;
+			
+			// aapt resource value: 0x7F020009
+			public static int mtrl_fab_transformation_sheet_expand_spec = 2130837513;
 			
 			static Animator()
 			{
@@ -72,58 +144,1435 @@ namespace AirshipBindings.NETStandard
 		{
 			
 			// aapt resource value: 0x7F030000
-			public static int messageCenterDividerColor = 2130903040;
+			public static int actionBarDivider = 2130903040;
 			
 			// aapt resource value: 0x7F030001
-			public static int messageCenterEmptyMessageText = 2130903041;
+			public static int actionBarItemBackground = 2130903041;
 			
 			// aapt resource value: 0x7F030002
-			public static int messageCenterEmptyMessageTextAppearance = 2130903042;
+			public static int actionBarPopupTheme = 2130903042;
 			
 			// aapt resource value: 0x7F030003
-			public static int messageCenterItemBackground = 2130903043;
+			public static int actionBarSize = 2130903043;
 			
 			// aapt resource value: 0x7F030004
-			public static int messageCenterItemDateTextAppearance = 2130903044;
+			public static int actionBarSplitStyle = 2130903044;
 			
 			// aapt resource value: 0x7F030005
-			public static int messageCenterItemIconEnabled = 2130903045;
+			public static int actionBarStyle = 2130903045;
 			
 			// aapt resource value: 0x7F030006
-			public static int messageCenterItemIconPlaceholder = 2130903046;
+			public static int actionBarTabBarStyle = 2130903046;
 			
 			// aapt resource value: 0x7F030007
-			public static int messageCenterItemTitleTextAppearance = 2130903047;
+			public static int actionBarTabStyle = 2130903047;
 			
 			// aapt resource value: 0x7F030008
-			public static int messageCenterStyle = 2130903048;
+			public static int actionBarTabTextStyle = 2130903048;
 			
 			// aapt resource value: 0x7F030009
-			public static int messageNotSelectedText = 2130903049;
+			public static int actionBarTheme = 2130903049;
 			
 			// aapt resource value: 0x7F03000A
-			public static int messageNotSelectedTextAppearance = 2130903050;
+			public static int actionBarWidgetTheme = 2130903050;
 			
 			// aapt resource value: 0x7F03000B
-			public static int mixed_content_mode = 2130903051;
+			public static int actionButtonStyle = 2130903051;
 			
 			// aapt resource value: 0x7F03000C
-			public static int ua_state_highlighted = 2130903052;
+			public static int actionDropDownStyle = 2130903052;
 			
 			// aapt resource value: 0x7F03000D
-			public static int urbanAirshipButtonLayoutResourceId = 2130903053;
+			public static int actionLayout = 2130903053;
 			
 			// aapt resource value: 0x7F03000E
-			public static int urbanAirshipMaxHeight = 2130903054;
+			public static int actionMenuTextAppearance = 2130903054;
 			
 			// aapt resource value: 0x7F03000F
-			public static int urbanAirshipMaxWidth = 2130903055;
+			public static int actionMenuTextColor = 2130903055;
 			
 			// aapt resource value: 0x7F030010
-			public static int urbanAirshipSeparatedSpaceWidth = 2130903056;
+			public static int actionModeBackground = 2130903056;
 			
 			// aapt resource value: 0x7F030011
-			public static int urbanAirshipStackedSpaceHeight = 2130903057;
+			public static int actionModeCloseButtonStyle = 2130903057;
+			
+			// aapt resource value: 0x7F030012
+			public static int actionModeCloseDrawable = 2130903058;
+			
+			// aapt resource value: 0x7F030013
+			public static int actionModeCopyDrawable = 2130903059;
+			
+			// aapt resource value: 0x7F030014
+			public static int actionModeCutDrawable = 2130903060;
+			
+			// aapt resource value: 0x7F030015
+			public static int actionModeFindDrawable = 2130903061;
+			
+			// aapt resource value: 0x7F030016
+			public static int actionModePasteDrawable = 2130903062;
+			
+			// aapt resource value: 0x7F030017
+			public static int actionModePopupWindowStyle = 2130903063;
+			
+			// aapt resource value: 0x7F030018
+			public static int actionModeSelectAllDrawable = 2130903064;
+			
+			// aapt resource value: 0x7F030019
+			public static int actionModeShareDrawable = 2130903065;
+			
+			// aapt resource value: 0x7F03001A
+			public static int actionModeSplitBackground = 2130903066;
+			
+			// aapt resource value: 0x7F03001B
+			public static int actionModeStyle = 2130903067;
+			
+			// aapt resource value: 0x7F03001C
+			public static int actionModeWebSearchDrawable = 2130903068;
+			
+			// aapt resource value: 0x7F03001D
+			public static int actionOverflowButtonStyle = 2130903069;
+			
+			// aapt resource value: 0x7F03001E
+			public static int actionOverflowMenuStyle = 2130903070;
+			
+			// aapt resource value: 0x7F03001F
+			public static int actionProviderClass = 2130903071;
+			
+			// aapt resource value: 0x7F030020
+			public static int actionViewClass = 2130903072;
+			
+			// aapt resource value: 0x7F030021
+			public static int activityChooserViewStyle = 2130903073;
+			
+			// aapt resource value: 0x7F030022
+			public static int alertDialogButtonGroupStyle = 2130903074;
+			
+			// aapt resource value: 0x7F030023
+			public static int alertDialogCenterButtons = 2130903075;
+			
+			// aapt resource value: 0x7F030024
+			public static int alertDialogStyle = 2130903076;
+			
+			// aapt resource value: 0x7F030025
+			public static int alertDialogTheme = 2130903077;
+			
+			// aapt resource value: 0x7F030026
+			public static int allowStacking = 2130903078;
+			
+			// aapt resource value: 0x7F030027
+			public static int alpha = 2130903079;
+			
+			// aapt resource value: 0x7F030028
+			public static int alphabeticModifiers = 2130903080;
+			
+			// aapt resource value: 0x7F030029
+			public static int arrowHeadLength = 2130903081;
+			
+			// aapt resource value: 0x7F03002A
+			public static int arrowShaftLength = 2130903082;
+			
+			// aapt resource value: 0x7F03002B
+			public static int autoCompleteTextViewStyle = 2130903083;
+			
+			// aapt resource value: 0x7F03002C
+			public static int autoSizeMaxTextSize = 2130903084;
+			
+			// aapt resource value: 0x7F03002D
+			public static int autoSizeMinTextSize = 2130903085;
+			
+			// aapt resource value: 0x7F03002E
+			public static int autoSizePresetSizes = 2130903086;
+			
+			// aapt resource value: 0x7F03002F
+			public static int autoSizeStepGranularity = 2130903087;
+			
+			// aapt resource value: 0x7F030030
+			public static int autoSizeTextType = 2130903088;
+			
+			// aapt resource value: 0x7F030031
+			public static int background = 2130903089;
+			
+			// aapt resource value: 0x7F030032
+			public static int backgroundSplit = 2130903090;
+			
+			// aapt resource value: 0x7F030033
+			public static int backgroundStacked = 2130903091;
+			
+			// aapt resource value: 0x7F030034
+			public static int backgroundTint = 2130903092;
+			
+			// aapt resource value: 0x7F030035
+			public static int backgroundTintMode = 2130903093;
+			
+			// aapt resource value: 0x7F030036
+			public static int barLength = 2130903094;
+			
+			// aapt resource value: 0x7F030037
+			public static int behavior_autoHide = 2130903095;
+			
+			// aapt resource value: 0x7F030038
+			public static int behavior_fitToContents = 2130903096;
+			
+			// aapt resource value: 0x7F030039
+			public static int behavior_hideable = 2130903097;
+			
+			// aapt resource value: 0x7F03003A
+			public static int behavior_overlapTop = 2130903098;
+			
+			// aapt resource value: 0x7F03003B
+			public static int behavior_peekHeight = 2130903099;
+			
+			// aapt resource value: 0x7F03003C
+			public static int behavior_skipCollapsed = 2130903100;
+			
+			// aapt resource value: 0x7F03003E
+			public static int borderlessButtonStyle = 2130903102;
+			
+			// aapt resource value: 0x7F03003D
+			public static int borderWidth = 2130903101;
+			
+			// aapt resource value: 0x7F03003F
+			public static int bottomAppBarStyle = 2130903103;
+			
+			// aapt resource value: 0x7F030040
+			public static int bottomNavigationStyle = 2130903104;
+			
+			// aapt resource value: 0x7F030041
+			public static int bottomSheetDialogTheme = 2130903105;
+			
+			// aapt resource value: 0x7F030042
+			public static int bottomSheetStyle = 2130903106;
+			
+			// aapt resource value: 0x7F030043
+			public static int boxBackgroundColor = 2130903107;
+			
+			// aapt resource value: 0x7F030044
+			public static int boxBackgroundMode = 2130903108;
+			
+			// aapt resource value: 0x7F030045
+			public static int boxCollapsedPaddingTop = 2130903109;
+			
+			// aapt resource value: 0x7F030046
+			public static int boxCornerRadiusBottomEnd = 2130903110;
+			
+			// aapt resource value: 0x7F030047
+			public static int boxCornerRadiusBottomStart = 2130903111;
+			
+			// aapt resource value: 0x7F030048
+			public static int boxCornerRadiusTopEnd = 2130903112;
+			
+			// aapt resource value: 0x7F030049
+			public static int boxCornerRadiusTopStart = 2130903113;
+			
+			// aapt resource value: 0x7F03004A
+			public static int boxStrokeColor = 2130903114;
+			
+			// aapt resource value: 0x7F03004B
+			public static int boxStrokeWidth = 2130903115;
+			
+			// aapt resource value: 0x7F03004C
+			public static int buttonBarButtonStyle = 2130903116;
+			
+			// aapt resource value: 0x7F03004D
+			public static int buttonBarNegativeButtonStyle = 2130903117;
+			
+			// aapt resource value: 0x7F03004E
+			public static int buttonBarNeutralButtonStyle = 2130903118;
+			
+			// aapt resource value: 0x7F03004F
+			public static int buttonBarPositiveButtonStyle = 2130903119;
+			
+			// aapt resource value: 0x7F030050
+			public static int buttonBarStyle = 2130903120;
+			
+			// aapt resource value: 0x7F030051
+			public static int buttonGravity = 2130903121;
+			
+			// aapt resource value: 0x7F030052
+			public static int buttonIconDimen = 2130903122;
+			
+			// aapt resource value: 0x7F030053
+			public static int buttonPanelSideLayout = 2130903123;
+			
+			// aapt resource value: 0x7F030054
+			public static int buttonStyle = 2130903124;
+			
+			// aapt resource value: 0x7F030055
+			public static int buttonStyleSmall = 2130903125;
+			
+			// aapt resource value: 0x7F030056
+			public static int buttonTint = 2130903126;
+			
+			// aapt resource value: 0x7F030057
+			public static int buttonTintMode = 2130903127;
+			
+			// aapt resource value: 0x7F030058
+			public static int cardBackgroundColor = 2130903128;
+			
+			// aapt resource value: 0x7F030059
+			public static int cardCornerRadius = 2130903129;
+			
+			// aapt resource value: 0x7F03005A
+			public static int cardElevation = 2130903130;
+			
+			// aapt resource value: 0x7F03005B
+			public static int cardMaxElevation = 2130903131;
+			
+			// aapt resource value: 0x7F03005C
+			public static int cardPreventCornerOverlap = 2130903132;
+			
+			// aapt resource value: 0x7F03005D
+			public static int cardUseCompatPadding = 2130903133;
+			
+			// aapt resource value: 0x7F03005E
+			public static int cardViewStyle = 2130903134;
+			
+			// aapt resource value: 0x7F03005F
+			public static int checkboxStyle = 2130903135;
+			
+			// aapt resource value: 0x7F030060
+			public static int checkedChip = 2130903136;
+			
+			// aapt resource value: 0x7F030061
+			public static int checkedIcon = 2130903137;
+			
+			// aapt resource value: 0x7F030062
+			public static int checkedIconEnabled = 2130903138;
+			
+			// aapt resource value: 0x7F030063
+			public static int checkedIconVisible = 2130903139;
+			
+			// aapt resource value: 0x7F030064
+			public static int checkedTextViewStyle = 2130903140;
+			
+			// aapt resource value: 0x7F030065
+			public static int chipBackgroundColor = 2130903141;
+			
+			// aapt resource value: 0x7F030066
+			public static int chipCornerRadius = 2130903142;
+			
+			// aapt resource value: 0x7F030067
+			public static int chipEndPadding = 2130903143;
+			
+			// aapt resource value: 0x7F030068
+			public static int chipGroupStyle = 2130903144;
+			
+			// aapt resource value: 0x7F030069
+			public static int chipIcon = 2130903145;
+			
+			// aapt resource value: 0x7F03006A
+			public static int chipIconEnabled = 2130903146;
+			
+			// aapt resource value: 0x7F03006B
+			public static int chipIconSize = 2130903147;
+			
+			// aapt resource value: 0x7F03006C
+			public static int chipIconTint = 2130903148;
+			
+			// aapt resource value: 0x7F03006D
+			public static int chipIconVisible = 2130903149;
+			
+			// aapt resource value: 0x7F03006E
+			public static int chipMinHeight = 2130903150;
+			
+			// aapt resource value: 0x7F03006F
+			public static int chipSpacing = 2130903151;
+			
+			// aapt resource value: 0x7F030070
+			public static int chipSpacingHorizontal = 2130903152;
+			
+			// aapt resource value: 0x7F030071
+			public static int chipSpacingVertical = 2130903153;
+			
+			// aapt resource value: 0x7F030072
+			public static int chipStandaloneStyle = 2130903154;
+			
+			// aapt resource value: 0x7F030073
+			public static int chipStartPadding = 2130903155;
+			
+			// aapt resource value: 0x7F030074
+			public static int chipStrokeColor = 2130903156;
+			
+			// aapt resource value: 0x7F030075
+			public static int chipStrokeWidth = 2130903157;
+			
+			// aapt resource value: 0x7F030076
+			public static int chipStyle = 2130903158;
+			
+			// aapt resource value: 0x7F030077
+			public static int closeIcon = 2130903159;
+			
+			// aapt resource value: 0x7F030078
+			public static int closeIconEnabled = 2130903160;
+			
+			// aapt resource value: 0x7F030079
+			public static int closeIconEndPadding = 2130903161;
+			
+			// aapt resource value: 0x7F03007A
+			public static int closeIconSize = 2130903162;
+			
+			// aapt resource value: 0x7F03007B
+			public static int closeIconStartPadding = 2130903163;
+			
+			// aapt resource value: 0x7F03007C
+			public static int closeIconTint = 2130903164;
+			
+			// aapt resource value: 0x7F03007D
+			public static int closeIconVisible = 2130903165;
+			
+			// aapt resource value: 0x7F03007E
+			public static int closeItemLayout = 2130903166;
+			
+			// aapt resource value: 0x7F03007F
+			public static int collapseContentDescription = 2130903167;
+			
+			// aapt resource value: 0x7F030081
+			public static int collapsedTitleGravity = 2130903169;
+			
+			// aapt resource value: 0x7F030082
+			public static int collapsedTitleTextAppearance = 2130903170;
+			
+			// aapt resource value: 0x7F030080
+			public static int collapseIcon = 2130903168;
+			
+			// aapt resource value: 0x7F030083
+			public static int color = 2130903171;
+			
+			// aapt resource value: 0x7F030084
+			public static int colorAccent = 2130903172;
+			
+			// aapt resource value: 0x7F030085
+			public static int colorBackgroundFloating = 2130903173;
+			
+			// aapt resource value: 0x7F030086
+			public static int colorButtonNormal = 2130903174;
+			
+			// aapt resource value: 0x7F030087
+			public static int colorControlActivated = 2130903175;
+			
+			// aapt resource value: 0x7F030088
+			public static int colorControlHighlight = 2130903176;
+			
+			// aapt resource value: 0x7F030089
+			public static int colorControlNormal = 2130903177;
+			
+			// aapt resource value: 0x7F03008A
+			public static int colorError = 2130903178;
+			
+			// aapt resource value: 0x7F03008B
+			public static int colorPrimary = 2130903179;
+			
+			// aapt resource value: 0x7F03008C
+			public static int colorPrimaryDark = 2130903180;
+			
+			// aapt resource value: 0x7F03008D
+			public static int colorSecondary = 2130903181;
+			
+			// aapt resource value: 0x7F03008E
+			public static int colorSwitchThumbNormal = 2130903182;
+			
+			// aapt resource value: 0x7F03008F
+			public static int commitIcon = 2130903183;
+			
+			// aapt resource value: 0x7F030090
+			public static int contentDescription = 2130903184;
+			
+			// aapt resource value: 0x7F030091
+			public static int contentInsetEnd = 2130903185;
+			
+			// aapt resource value: 0x7F030092
+			public static int contentInsetEndWithActions = 2130903186;
+			
+			// aapt resource value: 0x7F030093
+			public static int contentInsetLeft = 2130903187;
+			
+			// aapt resource value: 0x7F030094
+			public static int contentInsetRight = 2130903188;
+			
+			// aapt resource value: 0x7F030095
+			public static int contentInsetStart = 2130903189;
+			
+			// aapt resource value: 0x7F030096
+			public static int contentInsetStartWithNavigation = 2130903190;
+			
+			// aapt resource value: 0x7F030097
+			public static int contentPadding = 2130903191;
+			
+			// aapt resource value: 0x7F030098
+			public static int contentPaddingBottom = 2130903192;
+			
+			// aapt resource value: 0x7F030099
+			public static int contentPaddingLeft = 2130903193;
+			
+			// aapt resource value: 0x7F03009A
+			public static int contentPaddingRight = 2130903194;
+			
+			// aapt resource value: 0x7F03009B
+			public static int contentPaddingTop = 2130903195;
+			
+			// aapt resource value: 0x7F03009C
+			public static int contentScrim = 2130903196;
+			
+			// aapt resource value: 0x7F03009D
+			public static int controlBackground = 2130903197;
+			
+			// aapt resource value: 0x7F03009E
+			public static int coordinatorLayoutStyle = 2130903198;
+			
+			// aapt resource value: 0x7F03009F
+			public static int cornerRadius = 2130903199;
+			
+			// aapt resource value: 0x7F0300A0
+			public static int counterEnabled = 2130903200;
+			
+			// aapt resource value: 0x7F0300A1
+			public static int counterMaxLength = 2130903201;
+			
+			// aapt resource value: 0x7F0300A2
+			public static int counterOverflowTextAppearance = 2130903202;
+			
+			// aapt resource value: 0x7F0300A3
+			public static int counterTextAppearance = 2130903203;
+			
+			// aapt resource value: 0x7F0300A4
+			public static int customNavigationLayout = 2130903204;
+			
+			// aapt resource value: 0x7F0300A5
+			public static int defaultQueryHint = 2130903205;
+			
+			// aapt resource value: 0x7F0300A6
+			public static int dialogCornerRadius = 2130903206;
+			
+			// aapt resource value: 0x7F0300A7
+			public static int dialogPreferredPadding = 2130903207;
+			
+			// aapt resource value: 0x7F0300A8
+			public static int dialogTheme = 2130903208;
+			
+			// aapt resource value: 0x7F0300A9
+			public static int displayOptions = 2130903209;
+			
+			// aapt resource value: 0x7F0300AA
+			public static int divider = 2130903210;
+			
+			// aapt resource value: 0x7F0300AB
+			public static int dividerHorizontal = 2130903211;
+			
+			// aapt resource value: 0x7F0300AC
+			public static int dividerPadding = 2130903212;
+			
+			// aapt resource value: 0x7F0300AD
+			public static int dividerVertical = 2130903213;
+			
+			// aapt resource value: 0x7F0300AE
+			public static int drawableSize = 2130903214;
+			
+			// aapt resource value: 0x7F0300AF
+			public static int drawerArrowStyle = 2130903215;
+			
+			// aapt resource value: 0x7F0300B1
+			public static int dropdownListPreferredItemHeight = 2130903217;
+			
+			// aapt resource value: 0x7F0300B0
+			public static int dropDownListViewStyle = 2130903216;
+			
+			// aapt resource value: 0x7F0300B2
+			public static int editTextBackground = 2130903218;
+			
+			// aapt resource value: 0x7F0300B3
+			public static int editTextColor = 2130903219;
+			
+			// aapt resource value: 0x7F0300B4
+			public static int editTextStyle = 2130903220;
+			
+			// aapt resource value: 0x7F0300B5
+			public static int elevation = 2130903221;
+			
+			// aapt resource value: 0x7F0300B6
+			public static int enforceMaterialTheme = 2130903222;
+			
+			// aapt resource value: 0x7F0300B7
+			public static int enforceTextAppearance = 2130903223;
+			
+			// aapt resource value: 0x7F0300B8
+			public static int errorEnabled = 2130903224;
+			
+			// aapt resource value: 0x7F0300B9
+			public static int errorTextAppearance = 2130903225;
+			
+			// aapt resource value: 0x7F0300BA
+			public static int expandActivityOverflowButtonDrawable = 2130903226;
+			
+			// aapt resource value: 0x7F0300BB
+			public static int expanded = 2130903227;
+			
+			// aapt resource value: 0x7F0300BC
+			public static int expandedTitleGravity = 2130903228;
+			
+			// aapt resource value: 0x7F0300BD
+			public static int expandedTitleMargin = 2130903229;
+			
+			// aapt resource value: 0x7F0300BE
+			public static int expandedTitleMarginBottom = 2130903230;
+			
+			// aapt resource value: 0x7F0300BF
+			public static int expandedTitleMarginEnd = 2130903231;
+			
+			// aapt resource value: 0x7F0300C0
+			public static int expandedTitleMarginStart = 2130903232;
+			
+			// aapt resource value: 0x7F0300C1
+			public static int expandedTitleMarginTop = 2130903233;
+			
+			// aapt resource value: 0x7F0300C2
+			public static int expandedTitleTextAppearance = 2130903234;
+			
+			// aapt resource value: 0x7F0300C3
+			public static int fabAlignmentMode = 2130903235;
+			
+			// aapt resource value: 0x7F0300C4
+			public static int fabCradleMargin = 2130903236;
+			
+			// aapt resource value: 0x7F0300C5
+			public static int fabCradleRoundedCornerRadius = 2130903237;
+			
+			// aapt resource value: 0x7F0300C6
+			public static int fabCradleVerticalOffset = 2130903238;
+			
+			// aapt resource value: 0x7F0300C7
+			public static int fabCustomSize = 2130903239;
+			
+			// aapt resource value: 0x7F0300C8
+			public static int fabSize = 2130903240;
+			
+			// aapt resource value: 0x7F0300C9
+			public static int fastScrollEnabled = 2130903241;
+			
+			// aapt resource value: 0x7F0300CA
+			public static int fastScrollHorizontalThumbDrawable = 2130903242;
+			
+			// aapt resource value: 0x7F0300CB
+			public static int fastScrollHorizontalTrackDrawable = 2130903243;
+			
+			// aapt resource value: 0x7F0300CC
+			public static int fastScrollVerticalThumbDrawable = 2130903244;
+			
+			// aapt resource value: 0x7F0300CD
+			public static int fastScrollVerticalTrackDrawable = 2130903245;
+			
+			// aapt resource value: 0x7F0300CE
+			public static int firstBaselineToTopHeight = 2130903246;
+			
+			// aapt resource value: 0x7F0300CF
+			public static int floatingActionButtonStyle = 2130903247;
+			
+			// aapt resource value: 0x7F0300D0
+			public static int font = 2130903248;
+			
+			// aapt resource value: 0x7F0300D1
+			public static int fontFamily = 2130903249;
+			
+			// aapt resource value: 0x7F0300D2
+			public static int fontProviderAuthority = 2130903250;
+			
+			// aapt resource value: 0x7F0300D3
+			public static int fontProviderCerts = 2130903251;
+			
+			// aapt resource value: 0x7F0300D4
+			public static int fontProviderFetchStrategy = 2130903252;
+			
+			// aapt resource value: 0x7F0300D5
+			public static int fontProviderFetchTimeout = 2130903253;
+			
+			// aapt resource value: 0x7F0300D6
+			public static int fontProviderPackage = 2130903254;
+			
+			// aapt resource value: 0x7F0300D7
+			public static int fontProviderQuery = 2130903255;
+			
+			// aapt resource value: 0x7F0300D8
+			public static int fontStyle = 2130903256;
+			
+			// aapt resource value: 0x7F0300D9
+			public static int fontVariationSettings = 2130903257;
+			
+			// aapt resource value: 0x7F0300DA
+			public static int fontWeight = 2130903258;
+			
+			// aapt resource value: 0x7F0300DB
+			public static int foregroundInsidePadding = 2130903259;
+			
+			// aapt resource value: 0x7F0300DC
+			public static int gapBetweenBars = 2130903260;
+			
+			// aapt resource value: 0x7F0300DD
+			public static int goIcon = 2130903261;
+			
+			// aapt resource value: 0x7F0300DE
+			public static int headerLayout = 2130903262;
+			
+			// aapt resource value: 0x7F0300DF
+			public static int height = 2130903263;
+			
+			// aapt resource value: 0x7F0300E0
+			public static int helperText = 2130903264;
+			
+			// aapt resource value: 0x7F0300E1
+			public static int helperTextEnabled = 2130903265;
+			
+			// aapt resource value: 0x7F0300E2
+			public static int helperTextTextAppearance = 2130903266;
+			
+			// aapt resource value: 0x7F0300E3
+			public static int hideMotionSpec = 2130903267;
+			
+			// aapt resource value: 0x7F0300E4
+			public static int hideOnContentScroll = 2130903268;
+			
+			// aapt resource value: 0x7F0300E5
+			public static int hideOnScroll = 2130903269;
+			
+			// aapt resource value: 0x7F0300E6
+			public static int hintAnimationEnabled = 2130903270;
+			
+			// aapt resource value: 0x7F0300E7
+			public static int hintEnabled = 2130903271;
+			
+			// aapt resource value: 0x7F0300E8
+			public static int hintTextAppearance = 2130903272;
+			
+			// aapt resource value: 0x7F0300E9
+			public static int homeAsUpIndicator = 2130903273;
+			
+			// aapt resource value: 0x7F0300EA
+			public static int homeLayout = 2130903274;
+			
+			// aapt resource value: 0x7F0300EB
+			public static int hoveredFocusedTranslationZ = 2130903275;
+			
+			// aapt resource value: 0x7F0300EC
+			public static int icon = 2130903276;
+			
+			// aapt resource value: 0x7F0300ED
+			public static int iconEndPadding = 2130903277;
+			
+			// aapt resource value: 0x7F0300EE
+			public static int iconGravity = 2130903278;
+			
+			// aapt resource value: 0x7F0300F4
+			public static int iconifiedByDefault = 2130903284;
+			
+			// aapt resource value: 0x7F0300EF
+			public static int iconPadding = 2130903279;
+			
+			// aapt resource value: 0x7F0300F0
+			public static int iconSize = 2130903280;
+			
+			// aapt resource value: 0x7F0300F1
+			public static int iconStartPadding = 2130903281;
+			
+			// aapt resource value: 0x7F0300F2
+			public static int iconTint = 2130903282;
+			
+			// aapt resource value: 0x7F0300F3
+			public static int iconTintMode = 2130903283;
+			
+			// aapt resource value: 0x7F0300F5
+			public static int imageButtonStyle = 2130903285;
+			
+			// aapt resource value: 0x7F0300F6
+			public static int indeterminateProgressStyle = 2130903286;
+			
+			// aapt resource value: 0x7F0300F7
+			public static int initialActivityCount = 2130903287;
+			
+			// aapt resource value: 0x7F0300F8
+			public static int insetForeground = 2130903288;
+			
+			// aapt resource value: 0x7F0300F9
+			public static int isLightTheme = 2130903289;
+			
+			// aapt resource value: 0x7F0300FA
+			public static int itemBackground = 2130903290;
+			
+			// aapt resource value: 0x7F0300FB
+			public static int itemHorizontalPadding = 2130903291;
+			
+			// aapt resource value: 0x7F0300FC
+			public static int itemHorizontalTranslationEnabled = 2130903292;
+			
+			// aapt resource value: 0x7F0300FD
+			public static int itemIconPadding = 2130903293;
+			
+			// aapt resource value: 0x7F0300FE
+			public static int itemIconSize = 2130903294;
+			
+			// aapt resource value: 0x7F0300FF
+			public static int itemIconTint = 2130903295;
+			
+			// aapt resource value: 0x7F030100
+			public static int itemPadding = 2130903296;
+			
+			// aapt resource value: 0x7F030101
+			public static int itemSpacing = 2130903297;
+			
+			// aapt resource value: 0x7F030102
+			public static int itemTextAppearance = 2130903298;
+			
+			// aapt resource value: 0x7F030103
+			public static int itemTextAppearanceActive = 2130903299;
+			
+			// aapt resource value: 0x7F030104
+			public static int itemTextAppearanceInactive = 2130903300;
+			
+			// aapt resource value: 0x7F030105
+			public static int itemTextColor = 2130903301;
+			
+			// aapt resource value: 0x7F030106
+			public static int keylines = 2130903302;
+			
+			// aapt resource value: 0x7F030107
+			public static int labelVisibilityMode = 2130903303;
+			
+			// aapt resource value: 0x7F030108
+			public static int lastBaselineToBottomHeight = 2130903304;
+			
+			// aapt resource value: 0x7F030109
+			public static int layout = 2130903305;
+			
+			// aapt resource value: 0x7F03010A
+			public static int layoutManager = 2130903306;
+			
+			// aapt resource value: 0x7F03010B
+			public static int layout_anchor = 2130903307;
+			
+			// aapt resource value: 0x7F03010C
+			public static int layout_anchorGravity = 2130903308;
+			
+			// aapt resource value: 0x7F03010D
+			public static int layout_behavior = 2130903309;
+			
+			// aapt resource value: 0x7F03010E
+			public static int layout_collapseMode = 2130903310;
+			
+			// aapt resource value: 0x7F03010F
+			public static int layout_collapseParallaxMultiplier = 2130903311;
+			
+			// aapt resource value: 0x7F030110
+			public static int layout_dodgeInsetEdges = 2130903312;
+			
+			// aapt resource value: 0x7F030111
+			public static int layout_insetEdge = 2130903313;
+			
+			// aapt resource value: 0x7F030112
+			public static int layout_keyline = 2130903314;
+			
+			// aapt resource value: 0x7F030113
+			public static int layout_scrollFlags = 2130903315;
+			
+			// aapt resource value: 0x7F030114
+			public static int layout_scrollInterpolator = 2130903316;
+			
+			// aapt resource value: 0x7F030115
+			public static int liftOnScroll = 2130903317;
+			
+			// aapt resource value: 0x7F030116
+			public static int lineHeight = 2130903318;
+			
+			// aapt resource value: 0x7F030117
+			public static int lineSpacing = 2130903319;
+			
+			// aapt resource value: 0x7F030118
+			public static int listChoiceBackgroundIndicator = 2130903320;
+			
+			// aapt resource value: 0x7F030119
+			public static int listDividerAlertDialog = 2130903321;
+			
+			// aapt resource value: 0x7F03011A
+			public static int listItemLayout = 2130903322;
+			
+			// aapt resource value: 0x7F03011B
+			public static int listLayout = 2130903323;
+			
+			// aapt resource value: 0x7F03011C
+			public static int listMenuViewStyle = 2130903324;
+			
+			// aapt resource value: 0x7F03011D
+			public static int listPopupWindowStyle = 2130903325;
+			
+			// aapt resource value: 0x7F03011E
+			public static int listPreferredItemHeight = 2130903326;
+			
+			// aapt resource value: 0x7F03011F
+			public static int listPreferredItemHeightLarge = 2130903327;
+			
+			// aapt resource value: 0x7F030120
+			public static int listPreferredItemHeightSmall = 2130903328;
+			
+			// aapt resource value: 0x7F030121
+			public static int listPreferredItemPaddingLeft = 2130903329;
+			
+			// aapt resource value: 0x7F030122
+			public static int listPreferredItemPaddingRight = 2130903330;
+			
+			// aapt resource value: 0x7F030123
+			public static int logo = 2130903331;
+			
+			// aapt resource value: 0x7F030124
+			public static int logoDescription = 2130903332;
+			
+			// aapt resource value: 0x7F030125
+			public static int materialButtonStyle = 2130903333;
+			
+			// aapt resource value: 0x7F030126
+			public static int materialCardViewStyle = 2130903334;
+			
+			// aapt resource value: 0x7F030127
+			public static int maxActionInlineWidth = 2130903335;
+			
+			// aapt resource value: 0x7F030128
+			public static int maxButtonHeight = 2130903336;
+			
+			// aapt resource value: 0x7F030129
+			public static int maxImageSize = 2130903337;
+			
+			// aapt resource value: 0x7F03012A
+			public static int measureWithLargestChild = 2130903338;
+			
+			// aapt resource value: 0x7F03012B
+			public static int menu = 2130903339;
+			
+			// aapt resource value: 0x7F03012C
+			public static int multiChoiceItemLayout = 2130903340;
+			
+			// aapt resource value: 0x7F03012D
+			public static int navigationContentDescription = 2130903341;
+			
+			// aapt resource value: 0x7F03012E
+			public static int navigationIcon = 2130903342;
+			
+			// aapt resource value: 0x7F03012F
+			public static int navigationMode = 2130903343;
+			
+			// aapt resource value: 0x7F030130
+			public static int navigationViewStyle = 2130903344;
+			
+			// aapt resource value: 0x7F030131
+			public static int numericModifiers = 2130903345;
+			
+			// aapt resource value: 0x7F030132
+			public static int overlapAnchor = 2130903346;
+			
+			// aapt resource value: 0x7F030133
+			public static int paddingBottomNoButtons = 2130903347;
+			
+			// aapt resource value: 0x7F030134
+			public static int paddingEnd = 2130903348;
+			
+			// aapt resource value: 0x7F030135
+			public static int paddingStart = 2130903349;
+			
+			// aapt resource value: 0x7F030136
+			public static int paddingTopNoTitle = 2130903350;
+			
+			// aapt resource value: 0x7F030137
+			public static int panelBackground = 2130903351;
+			
+			// aapt resource value: 0x7F030138
+			public static int panelMenuListTheme = 2130903352;
+			
+			// aapt resource value: 0x7F030139
+			public static int panelMenuListWidth = 2130903353;
+			
+			// aapt resource value: 0x7F03013A
+			public static int passwordToggleContentDescription = 2130903354;
+			
+			// aapt resource value: 0x7F03013B
+			public static int passwordToggleDrawable = 2130903355;
+			
+			// aapt resource value: 0x7F03013C
+			public static int passwordToggleEnabled = 2130903356;
+			
+			// aapt resource value: 0x7F03013D
+			public static int passwordToggleTint = 2130903357;
+			
+			// aapt resource value: 0x7F03013E
+			public static int passwordToggleTintMode = 2130903358;
+			
+			// aapt resource value: 0x7F03013F
+			public static int popupMenuStyle = 2130903359;
+			
+			// aapt resource value: 0x7F030140
+			public static int popupTheme = 2130903360;
+			
+			// aapt resource value: 0x7F030141
+			public static int popupWindowStyle = 2130903361;
+			
+			// aapt resource value: 0x7F030142
+			public static int preserveIconSpacing = 2130903362;
+			
+			// aapt resource value: 0x7F030143
+			public static int pressedTranslationZ = 2130903363;
+			
+			// aapt resource value: 0x7F030144
+			public static int progressBarPadding = 2130903364;
+			
+			// aapt resource value: 0x7F030145
+			public static int progressBarStyle = 2130903365;
+			
+			// aapt resource value: 0x7F030146
+			public static int queryBackground = 2130903366;
+			
+			// aapt resource value: 0x7F030147
+			public static int queryHint = 2130903367;
+			
+			// aapt resource value: 0x7F030148
+			public static int radioButtonStyle = 2130903368;
+			
+			// aapt resource value: 0x7F030149
+			public static int ratingBarStyle = 2130903369;
+			
+			// aapt resource value: 0x7F03014A
+			public static int ratingBarStyleIndicator = 2130903370;
+			
+			// aapt resource value: 0x7F03014B
+			public static int ratingBarStyleSmall = 2130903371;
+			
+			// aapt resource value: 0x7F03014C
+			public static int reverseLayout = 2130903372;
+			
+			// aapt resource value: 0x7F03014D
+			public static int rippleColor = 2130903373;
+			
+			// aapt resource value: 0x7F03014E
+			public static int scrimAnimationDuration = 2130903374;
+			
+			// aapt resource value: 0x7F03014F
+			public static int scrimBackground = 2130903375;
+			
+			// aapt resource value: 0x7F030150
+			public static int scrimVisibleHeightTrigger = 2130903376;
+			
+			// aapt resource value: 0x7F030151
+			public static int searchHintIcon = 2130903377;
+			
+			// aapt resource value: 0x7F030152
+			public static int searchIcon = 2130903378;
+			
+			// aapt resource value: 0x7F030153
+			public static int searchViewStyle = 2130903379;
+			
+			// aapt resource value: 0x7F030154
+			public static int seekBarStyle = 2130903380;
+			
+			// aapt resource value: 0x7F030155
+			public static int selectableItemBackground = 2130903381;
+			
+			// aapt resource value: 0x7F030156
+			public static int selectableItemBackgroundBorderless = 2130903382;
+			
+			// aapt resource value: 0x7F030157
+			public static int showAsAction = 2130903383;
+			
+			// aapt resource value: 0x7F030158
+			public static int showDividers = 2130903384;
+			
+			// aapt resource value: 0x7F030159
+			public static int showMotionSpec = 2130903385;
+			
+			// aapt resource value: 0x7F03015A
+			public static int showText = 2130903386;
+			
+			// aapt resource value: 0x7F03015B
+			public static int showTitle = 2130903387;
+			
+			// aapt resource value: 0x7F03015C
+			public static int singleChoiceItemLayout = 2130903388;
+			
+			// aapt resource value: 0x7F03015D
+			public static int singleLine = 2130903389;
+			
+			// aapt resource value: 0x7F03015E
+			public static int singleSelection = 2130903390;
+			
+			// aapt resource value: 0x7F03015F
+			public static int snackbarButtonStyle = 2130903391;
+			
+			// aapt resource value: 0x7F030160
+			public static int snackbarStyle = 2130903392;
+			
+			// aapt resource value: 0x7F030161
+			public static int spanCount = 2130903393;
+			
+			// aapt resource value: 0x7F030162
+			public static int spinBars = 2130903394;
+			
+			// aapt resource value: 0x7F030163
+			public static int spinnerDropDownItemStyle = 2130903395;
+			
+			// aapt resource value: 0x7F030164
+			public static int spinnerStyle = 2130903396;
+			
+			// aapt resource value: 0x7F030165
+			public static int splitTrack = 2130903397;
+			
+			// aapt resource value: 0x7F030166
+			public static int srcCompat = 2130903398;
+			
+			// aapt resource value: 0x7F030167
+			public static int stackFromEnd = 2130903399;
+			
+			// aapt resource value: 0x7F030168
+			public static int state_above_anchor = 2130903400;
+			
+			// aapt resource value: 0x7F030169
+			public static int state_collapsed = 2130903401;
+			
+			// aapt resource value: 0x7F03016A
+			public static int state_collapsible = 2130903402;
+			
+			// aapt resource value: 0x7F03016B
+			public static int state_liftable = 2130903403;
+			
+			// aapt resource value: 0x7F03016C
+			public static int state_lifted = 2130903404;
+			
+			// aapt resource value: 0x7F03016D
+			public static int statusBarBackground = 2130903405;
+			
+			// aapt resource value: 0x7F03016E
+			public static int statusBarScrim = 2130903406;
+			
+			// aapt resource value: 0x7F03016F
+			public static int strokeColor = 2130903407;
+			
+			// aapt resource value: 0x7F030170
+			public static int strokeWidth = 2130903408;
+			
+			// aapt resource value: 0x7F030171
+			public static int subMenuArrow = 2130903409;
+			
+			// aapt resource value: 0x7F030172
+			public static int submitBackground = 2130903410;
+			
+			// aapt resource value: 0x7F030173
+			public static int subtitle = 2130903411;
+			
+			// aapt resource value: 0x7F030174
+			public static int subtitleTextAppearance = 2130903412;
+			
+			// aapt resource value: 0x7F030175
+			public static int subtitleTextColor = 2130903413;
+			
+			// aapt resource value: 0x7F030176
+			public static int subtitleTextStyle = 2130903414;
+			
+			// aapt resource value: 0x7F030177
+			public static int suggestionRowLayout = 2130903415;
+			
+			// aapt resource value: 0x7F030178
+			public static int switchMinWidth = 2130903416;
+			
+			// aapt resource value: 0x7F030179
+			public static int switchPadding = 2130903417;
+			
+			// aapt resource value: 0x7F03017A
+			public static int switchStyle = 2130903418;
+			
+			// aapt resource value: 0x7F03017B
+			public static int switchTextAppearance = 2130903419;
+			
+			// aapt resource value: 0x7F03017C
+			public static int tabBackground = 2130903420;
+			
+			// aapt resource value: 0x7F03017D
+			public static int tabContentStart = 2130903421;
+			
+			// aapt resource value: 0x7F03017E
+			public static int tabGravity = 2130903422;
+			
+			// aapt resource value: 0x7F03017F
+			public static int tabIconTint = 2130903423;
+			
+			// aapt resource value: 0x7F030180
+			public static int tabIconTintMode = 2130903424;
+			
+			// aapt resource value: 0x7F030181
+			public static int tabIndicator = 2130903425;
+			
+			// aapt resource value: 0x7F030182
+			public static int tabIndicatorAnimationDuration = 2130903426;
+			
+			// aapt resource value: 0x7F030183
+			public static int tabIndicatorColor = 2130903427;
+			
+			// aapt resource value: 0x7F030184
+			public static int tabIndicatorFullWidth = 2130903428;
+			
+			// aapt resource value: 0x7F030185
+			public static int tabIndicatorGravity = 2130903429;
+			
+			// aapt resource value: 0x7F030186
+			public static int tabIndicatorHeight = 2130903430;
+			
+			// aapt resource value: 0x7F030187
+			public static int tabInlineLabel = 2130903431;
+			
+			// aapt resource value: 0x7F030188
+			public static int tabMaxWidth = 2130903432;
+			
+			// aapt resource value: 0x7F030189
+			public static int tabMinWidth = 2130903433;
+			
+			// aapt resource value: 0x7F03018A
+			public static int tabMode = 2130903434;
+			
+			// aapt resource value: 0x7F03018B
+			public static int tabPadding = 2130903435;
+			
+			// aapt resource value: 0x7F03018C
+			public static int tabPaddingBottom = 2130903436;
+			
+			// aapt resource value: 0x7F03018D
+			public static int tabPaddingEnd = 2130903437;
+			
+			// aapt resource value: 0x7F03018E
+			public static int tabPaddingStart = 2130903438;
+			
+			// aapt resource value: 0x7F03018F
+			public static int tabPaddingTop = 2130903439;
+			
+			// aapt resource value: 0x7F030190
+			public static int tabRippleColor = 2130903440;
+			
+			// aapt resource value: 0x7F030191
+			public static int tabSelectedTextColor = 2130903441;
+			
+			// aapt resource value: 0x7F030192
+			public static int tabStyle = 2130903442;
+			
+			// aapt resource value: 0x7F030193
+			public static int tabTextAppearance = 2130903443;
+			
+			// aapt resource value: 0x7F030194
+			public static int tabTextColor = 2130903444;
+			
+			// aapt resource value: 0x7F030195
+			public static int tabUnboundedRipple = 2130903445;
+			
+			// aapt resource value: 0x7F030196
+			public static int textAllCaps = 2130903446;
+			
+			// aapt resource value: 0x7F030197
+			public static int textAppearanceBody1 = 2130903447;
+			
+			// aapt resource value: 0x7F030198
+			public static int textAppearanceBody2 = 2130903448;
+			
+			// aapt resource value: 0x7F030199
+			public static int textAppearanceButton = 2130903449;
+			
+			// aapt resource value: 0x7F03019A
+			public static int textAppearanceCaption = 2130903450;
+			
+			// aapt resource value: 0x7F03019B
+			public static int textAppearanceHeadline1 = 2130903451;
+			
+			// aapt resource value: 0x7F03019C
+			public static int textAppearanceHeadline2 = 2130903452;
+			
+			// aapt resource value: 0x7F03019D
+			public static int textAppearanceHeadline3 = 2130903453;
+			
+			// aapt resource value: 0x7F03019E
+			public static int textAppearanceHeadline4 = 2130903454;
+			
+			// aapt resource value: 0x7F03019F
+			public static int textAppearanceHeadline5 = 2130903455;
+			
+			// aapt resource value: 0x7F0301A0
+			public static int textAppearanceHeadline6 = 2130903456;
+			
+			// aapt resource value: 0x7F0301A1
+			public static int textAppearanceLargePopupMenu = 2130903457;
+			
+			// aapt resource value: 0x7F0301A2
+			public static int textAppearanceListItem = 2130903458;
+			
+			// aapt resource value: 0x7F0301A3
+			public static int textAppearanceListItemSecondary = 2130903459;
+			
+			// aapt resource value: 0x7F0301A4
+			public static int textAppearanceListItemSmall = 2130903460;
+			
+			// aapt resource value: 0x7F0301A5
+			public static int textAppearanceOverline = 2130903461;
+			
+			// aapt resource value: 0x7F0301A6
+			public static int textAppearancePopupMenuHeader = 2130903462;
+			
+			// aapt resource value: 0x7F0301A7
+			public static int textAppearanceSearchResultSubtitle = 2130903463;
+			
+			// aapt resource value: 0x7F0301A8
+			public static int textAppearanceSearchResultTitle = 2130903464;
+			
+			// aapt resource value: 0x7F0301A9
+			public static int textAppearanceSmallPopupMenu = 2130903465;
+			
+			// aapt resource value: 0x7F0301AA
+			public static int textAppearanceSubtitle1 = 2130903466;
+			
+			// aapt resource value: 0x7F0301AB
+			public static int textAppearanceSubtitle2 = 2130903467;
+			
+			// aapt resource value: 0x7F0301AC
+			public static int textColorAlertDialogListItem = 2130903468;
+			
+			// aapt resource value: 0x7F0301AD
+			public static int textColorSearchUrl = 2130903469;
+			
+			// aapt resource value: 0x7F0301AE
+			public static int textEndPadding = 2130903470;
+			
+			// aapt resource value: 0x7F0301AF
+			public static int textInputStyle = 2130903471;
+			
+			// aapt resource value: 0x7F0301B0
+			public static int textStartPadding = 2130903472;
+			
+			// aapt resource value: 0x7F0301B1
+			public static int theme = 2130903473;
+			
+			// aapt resource value: 0x7F0301B2
+			public static int thickness = 2130903474;
+			
+			// aapt resource value: 0x7F0301B3
+			public static int thumbTextPadding = 2130903475;
+			
+			// aapt resource value: 0x7F0301B4
+			public static int thumbTint = 2130903476;
+			
+			// aapt resource value: 0x7F0301B5
+			public static int thumbTintMode = 2130903477;
+			
+			// aapt resource value: 0x7F0301B6
+			public static int tickMark = 2130903478;
+			
+			// aapt resource value: 0x7F0301B7
+			public static int tickMarkTint = 2130903479;
+			
+			// aapt resource value: 0x7F0301B8
+			public static int tickMarkTintMode = 2130903480;
+			
+			// aapt resource value: 0x7F0301B9
+			public static int tint = 2130903481;
+			
+			// aapt resource value: 0x7F0301BA
+			public static int tintMode = 2130903482;
+			
+			// aapt resource value: 0x7F0301BB
+			public static int title = 2130903483;
+			
+			// aapt resource value: 0x7F0301BC
+			public static int titleEnabled = 2130903484;
+			
+			// aapt resource value: 0x7F0301BD
+			public static int titleMargin = 2130903485;
+			
+			// aapt resource value: 0x7F0301BE
+			public static int titleMarginBottom = 2130903486;
+			
+			// aapt resource value: 0x7F0301BF
+			public static int titleMarginEnd = 2130903487;
+			
+			// aapt resource value: 0x7F0301C2
+			public static int titleMargins = 2130903490;
+			
+			// aapt resource value: 0x7F0301C0
+			public static int titleMarginStart = 2130903488;
+			
+			// aapt resource value: 0x7F0301C1
+			public static int titleMarginTop = 2130903489;
+			
+			// aapt resource value: 0x7F0301C3
+			public static int titleTextAppearance = 2130903491;
+			
+			// aapt resource value: 0x7F0301C4
+			public static int titleTextColor = 2130903492;
+			
+			// aapt resource value: 0x7F0301C5
+			public static int titleTextStyle = 2130903493;
+			
+			// aapt resource value: 0x7F0301C6
+			public static int toolbarId = 2130903494;
+			
+			// aapt resource value: 0x7F0301C7
+			public static int toolbarNavigationButtonStyle = 2130903495;
+			
+			// aapt resource value: 0x7F0301C8
+			public static int toolbarStyle = 2130903496;
+			
+			// aapt resource value: 0x7F0301C9
+			public static int tooltipForegroundColor = 2130903497;
+			
+			// aapt resource value: 0x7F0301CA
+			public static int tooltipFrameBackground = 2130903498;
+			
+			// aapt resource value: 0x7F0301CB
+			public static int tooltipText = 2130903499;
+			
+			// aapt resource value: 0x7F0301CC
+			public static int track = 2130903500;
+			
+			// aapt resource value: 0x7F0301CD
+			public static int trackTint = 2130903501;
+			
+			// aapt resource value: 0x7F0301CE
+			public static int trackTintMode = 2130903502;
+			
+			// aapt resource value: 0x7F0301CF
+			public static int ttcIndex = 2130903503;
+			
+			// aapt resource value: 0x7F0301D0
+			public static int useCompatPadding = 2130903504;
+			
+			// aapt resource value: 0x7F0301D1
+			public static int viewInflaterClass = 2130903505;
+			
+			// aapt resource value: 0x7F0301D2
+			public static int voiceIcon = 2130903506;
+			
+			// aapt resource value: 0x7F0301D3
+			public static int windowActionBar = 2130903507;
+			
+			// aapt resource value: 0x7F0301D4
+			public static int windowActionBarOverlay = 2130903508;
+			
+			// aapt resource value: 0x7F0301D5
+			public static int windowActionModeOverlay = 2130903509;
+			
+			// aapt resource value: 0x7F0301D6
+			public static int windowFixedHeightMajor = 2130903510;
+			
+			// aapt resource value: 0x7F0301D7
+			public static int windowFixedHeightMinor = 2130903511;
+			
+			// aapt resource value: 0x7F0301D8
+			public static int windowFixedWidthMajor = 2130903512;
+			
+			// aapt resource value: 0x7F0301D9
+			public static int windowFixedWidthMinor = 2130903513;
+			
+			// aapt resource value: 0x7F0301DA
+			public static int windowMinWidthMajor = 2130903514;
+			
+			// aapt resource value: 0x7F0301DB
+			public static int windowMinWidthMinor = 2130903515;
+			
+			// aapt resource value: 0x7F0301DC
+			public static int windowNoTitle = 2130903516;
 			
 			static Attribute()
 			{
@@ -139,10 +1588,16 @@ namespace AirshipBindings.NETStandard
 		{
 			
 			// aapt resource value: 0x7F040000
-			public static int ua_iam_html_allow_fullscreen_display = 2130968576;
+			public static int abc_action_bar_embed_tabs = 2130968576;
 			
 			// aapt resource value: 0x7F040001
-			public static int ua_iam_modal_allow_fullscreen_display = 2130968577;
+			public static int abc_allow_stacked_button_bar = 2130968577;
+			
+			// aapt resource value: 0x7F040002
+			public static int abc_config_actionMenuItemAllCaps = 2130968578;
+			
+			// aapt resource value: 0x7F040003
+			public static int mtrl_btn_textappearance_all_caps = 2130968579;
 			
 			static Boolean()
 			{
@@ -154,92 +1609,1429 @@ namespace AirshipBindings.NETStandard
 			}
 		}
 		
-		public partial class Drawable
+		public partial class Color
 		{
 			
 			// aapt resource value: 0x7F050000
-			public static int ua_iam_banner_pull_background = 2131034112;
+			public static int abc_background_cache_hint_selector_material_dark = 2131034112;
 			
 			// aapt resource value: 0x7F050001
-			public static int ua_iam_dismiss_background = 2131034113;
+			public static int abc_background_cache_hint_selector_material_light = 2131034113;
 			
 			// aapt resource value: 0x7F050002
-			public static int ua_ic_close = 2131034114;
+			public static int abc_btn_colored_borderless_text_material = 2131034114;
 			
 			// aapt resource value: 0x7F050003
-			public static int ua_ic_close_white = 2131034115;
+			public static int abc_btn_colored_text_material = 2131034115;
 			
 			// aapt resource value: 0x7F050004
-			public static int ua_ic_image_placeholder = 2131034116;
+			public static int abc_color_highlight_material = 2131034116;
 			
 			// aapt resource value: 0x7F050005
-			public static int ua_ic_notification_button_accept = 2131034117;
+			public static int abc_hint_foreground_material_dark = 2131034117;
 			
 			// aapt resource value: 0x7F050006
-			public static int ua_ic_notification_button_add = 2131034118;
+			public static int abc_hint_foreground_material_light = 2131034118;
 			
 			// aapt resource value: 0x7F050007
-			public static int ua_ic_notification_button_book = 2131034119;
+			public static int abc_input_method_navigation_guard = 2131034119;
 			
 			// aapt resource value: 0x7F050008
-			public static int ua_ic_notification_button_cart = 2131034120;
+			public static int abc_primary_text_disable_only_material_dark = 2131034120;
 			
 			// aapt resource value: 0x7F050009
-			public static int ua_ic_notification_button_copy = 2131034121;
+			public static int abc_primary_text_disable_only_material_light = 2131034121;
 			
 			// aapt resource value: 0x7F05000A
-			public static int ua_ic_notification_button_decline = 2131034122;
+			public static int abc_primary_text_material_dark = 2131034122;
 			
 			// aapt resource value: 0x7F05000B
-			public static int ua_ic_notification_button_download = 2131034123;
+			public static int abc_primary_text_material_light = 2131034123;
 			
 			// aapt resource value: 0x7F05000C
-			public static int ua_ic_notification_button_event = 2131034124;
+			public static int abc_search_url_text = 2131034124;
 			
 			// aapt resource value: 0x7F05000D
-			public static int ua_ic_notification_button_follow = 2131034125;
+			public static int abc_search_url_text_normal = 2131034125;
 			
 			// aapt resource value: 0x7F05000E
-			public static int ua_ic_notification_button_happy = 2131034126;
+			public static int abc_search_url_text_pressed = 2131034126;
 			
 			// aapt resource value: 0x7F05000F
-			public static int ua_ic_notification_button_info = 2131034127;
+			public static int abc_search_url_text_selected = 2131034127;
 			
 			// aapt resource value: 0x7F050010
-			public static int ua_ic_notification_button_open_browser = 2131034128;
+			public static int abc_secondary_text_material_dark = 2131034128;
 			
 			// aapt resource value: 0x7F050011
-			public static int ua_ic_notification_button_remind = 2131034129;
+			public static int abc_secondary_text_material_light = 2131034129;
 			
 			// aapt resource value: 0x7F050012
-			public static int ua_ic_notification_button_sad = 2131034130;
+			public static int abc_tint_btn_checkable = 2131034130;
 			
 			// aapt resource value: 0x7F050013
-			public static int ua_ic_notification_button_save = 2131034131;
+			public static int abc_tint_default = 2131034131;
 			
 			// aapt resource value: 0x7F050014
-			public static int ua_ic_notification_button_search = 2131034132;
+			public static int abc_tint_edittext = 2131034132;
 			
 			// aapt resource value: 0x7F050015
-			public static int ua_ic_notification_button_send = 2131034133;
+			public static int abc_tint_seek_thumb = 2131034133;
 			
 			// aapt resource value: 0x7F050016
-			public static int ua_ic_notification_button_share = 2131034134;
+			public static int abc_tint_spinner = 2131034134;
 			
 			// aapt resource value: 0x7F050017
-			public static int ua_ic_notification_button_thumbs_down = 2131034135;
+			public static int abc_tint_switch_track = 2131034135;
 			
 			// aapt resource value: 0x7F050018
-			public static int ua_ic_notification_button_thumbs_up = 2131034136;
+			public static int accent_material_dark = 2131034136;
 			
 			// aapt resource value: 0x7F050019
-			public static int ua_ic_notification_button_unfollow = 2131034137;
+			public static int accent_material_light = 2131034137;
 			
 			// aapt resource value: 0x7F05001A
-			public static int ua_ic_urbanairship_notification = 2131034138;
+			public static int background_floating_material_dark = 2131034138;
 			
 			// aapt resource value: 0x7F05001B
-			public static int ua_item_mc_background = 2131034139;
+			public static int background_floating_material_light = 2131034139;
+			
+			// aapt resource value: 0x7F05001C
+			public static int background_material_dark = 2131034140;
+			
+			// aapt resource value: 0x7F05001D
+			public static int background_material_light = 2131034141;
+			
+			// aapt resource value: 0x7F05001E
+			public static int bright_foreground_disabled_material_dark = 2131034142;
+			
+			// aapt resource value: 0x7F05001F
+			public static int bright_foreground_disabled_material_light = 2131034143;
+			
+			// aapt resource value: 0x7F050020
+			public static int bright_foreground_inverse_material_dark = 2131034144;
+			
+			// aapt resource value: 0x7F050021
+			public static int bright_foreground_inverse_material_light = 2131034145;
+			
+			// aapt resource value: 0x7F050022
+			public static int bright_foreground_material_dark = 2131034146;
+			
+			// aapt resource value: 0x7F050023
+			public static int bright_foreground_material_light = 2131034147;
+			
+			// aapt resource value: 0x7F050024
+			public static int browser_actions_bg_grey = 2131034148;
+			
+			// aapt resource value: 0x7F050025
+			public static int browser_actions_divider_color = 2131034149;
+			
+			// aapt resource value: 0x7F050026
+			public static int browser_actions_text_color = 2131034150;
+			
+			// aapt resource value: 0x7F050027
+			public static int browser_actions_title_color = 2131034151;
+			
+			// aapt resource value: 0x7F050028
+			public static int button_material_dark = 2131034152;
+			
+			// aapt resource value: 0x7F050029
+			public static int button_material_light = 2131034153;
+			
+			// aapt resource value: 0x7F05002A
+			public static int cardview_dark_background = 2131034154;
+			
+			// aapt resource value: 0x7F05002B
+			public static int cardview_light_background = 2131034155;
+			
+			// aapt resource value: 0x7F05002C
+			public static int cardview_shadow_end_color = 2131034156;
+			
+			// aapt resource value: 0x7F05002D
+			public static int cardview_shadow_start_color = 2131034157;
+			
+			// aapt resource value: 0x7F05002E
+			public static int design_bottom_navigation_shadow_color = 2131034158;
+			
+			// aapt resource value: 0x7F05002F
+			public static int design_default_color_primary = 2131034159;
+			
+			// aapt resource value: 0x7F050030
+			public static int design_default_color_primary_dark = 2131034160;
+			
+			// aapt resource value: 0x7F050031
+			public static int design_error = 2131034161;
+			
+			// aapt resource value: 0x7F050032
+			public static int design_fab_shadow_end_color = 2131034162;
+			
+			// aapt resource value: 0x7F050033
+			public static int design_fab_shadow_mid_color = 2131034163;
+			
+			// aapt resource value: 0x7F050034
+			public static int design_fab_shadow_start_color = 2131034164;
+			
+			// aapt resource value: 0x7F050035
+			public static int design_fab_stroke_end_inner_color = 2131034165;
+			
+			// aapt resource value: 0x7F050036
+			public static int design_fab_stroke_end_outer_color = 2131034166;
+			
+			// aapt resource value: 0x7F050037
+			public static int design_fab_stroke_top_inner_color = 2131034167;
+			
+			// aapt resource value: 0x7F050038
+			public static int design_fab_stroke_top_outer_color = 2131034168;
+			
+			// aapt resource value: 0x7F050039
+			public static int design_snackbar_background_color = 2131034169;
+			
+			// aapt resource value: 0x7F05003A
+			public static int design_tint_password_toggle = 2131034170;
+			
+			// aapt resource value: 0x7F05003B
+			public static int dim_foreground_disabled_material_dark = 2131034171;
+			
+			// aapt resource value: 0x7F05003C
+			public static int dim_foreground_disabled_material_light = 2131034172;
+			
+			// aapt resource value: 0x7F05003D
+			public static int dim_foreground_material_dark = 2131034173;
+			
+			// aapt resource value: 0x7F05003E
+			public static int dim_foreground_material_light = 2131034174;
+			
+			// aapt resource value: 0x7F05003F
+			public static int error_color_material_dark = 2131034175;
+			
+			// aapt resource value: 0x7F050040
+			public static int error_color_material_light = 2131034176;
+			
+			// aapt resource value: 0x7F050041
+			public static int foreground_material_dark = 2131034177;
+			
+			// aapt resource value: 0x7F050042
+			public static int foreground_material_light = 2131034178;
+			
+			// aapt resource value: 0x7F050043
+			public static int highlighted_text_material_dark = 2131034179;
+			
+			// aapt resource value: 0x7F050044
+			public static int highlighted_text_material_light = 2131034180;
+			
+			// aapt resource value: 0x7F050045
+			public static int material_blue_grey_800 = 2131034181;
+			
+			// aapt resource value: 0x7F050046
+			public static int material_blue_grey_900 = 2131034182;
+			
+			// aapt resource value: 0x7F050047
+			public static int material_blue_grey_950 = 2131034183;
+			
+			// aapt resource value: 0x7F050048
+			public static int material_deep_teal_200 = 2131034184;
+			
+			// aapt resource value: 0x7F050049
+			public static int material_deep_teal_500 = 2131034185;
+			
+			// aapt resource value: 0x7F05004A
+			public static int material_grey_100 = 2131034186;
+			
+			// aapt resource value: 0x7F05004B
+			public static int material_grey_300 = 2131034187;
+			
+			// aapt resource value: 0x7F05004C
+			public static int material_grey_50 = 2131034188;
+			
+			// aapt resource value: 0x7F05004D
+			public static int material_grey_600 = 2131034189;
+			
+			// aapt resource value: 0x7F05004E
+			public static int material_grey_800 = 2131034190;
+			
+			// aapt resource value: 0x7F05004F
+			public static int material_grey_850 = 2131034191;
+			
+			// aapt resource value: 0x7F050050
+			public static int material_grey_900 = 2131034192;
+			
+			// aapt resource value: 0x7F050051
+			public static int mtrl_bottom_nav_colored_item_tint = 2131034193;
+			
+			// aapt resource value: 0x7F050052
+			public static int mtrl_bottom_nav_item_tint = 2131034194;
+			
+			// aapt resource value: 0x7F050053
+			public static int mtrl_btn_bg_color_disabled = 2131034195;
+			
+			// aapt resource value: 0x7F050054
+			public static int mtrl_btn_bg_color_selector = 2131034196;
+			
+			// aapt resource value: 0x7F050055
+			public static int mtrl_btn_ripple_color = 2131034197;
+			
+			// aapt resource value: 0x7F050056
+			public static int mtrl_btn_stroke_color_selector = 2131034198;
+			
+			// aapt resource value: 0x7F050057
+			public static int mtrl_btn_text_btn_ripple_color = 2131034199;
+			
+			// aapt resource value: 0x7F050058
+			public static int mtrl_btn_text_color_disabled = 2131034200;
+			
+			// aapt resource value: 0x7F050059
+			public static int mtrl_btn_text_color_selector = 2131034201;
+			
+			// aapt resource value: 0x7F05005A
+			public static int mtrl_btn_transparent_bg_color = 2131034202;
+			
+			// aapt resource value: 0x7F05005B
+			public static int mtrl_chip_background_color = 2131034203;
+			
+			// aapt resource value: 0x7F05005C
+			public static int mtrl_chip_close_icon_tint = 2131034204;
+			
+			// aapt resource value: 0x7F05005D
+			public static int mtrl_chip_ripple_color = 2131034205;
+			
+			// aapt resource value: 0x7F05005E
+			public static int mtrl_chip_text_color = 2131034206;
+			
+			// aapt resource value: 0x7F05005F
+			public static int mtrl_fab_ripple_color = 2131034207;
+			
+			// aapt resource value: 0x7F050060
+			public static int mtrl_scrim_color = 2131034208;
+			
+			// aapt resource value: 0x7F050061
+			public static int mtrl_tabs_colored_ripple_color = 2131034209;
+			
+			// aapt resource value: 0x7F050062
+			public static int mtrl_tabs_icon_color_selector = 2131034210;
+			
+			// aapt resource value: 0x7F050063
+			public static int mtrl_tabs_icon_color_selector_colored = 2131034211;
+			
+			// aapt resource value: 0x7F050064
+			public static int mtrl_tabs_legacy_text_color_selector = 2131034212;
+			
+			// aapt resource value: 0x7F050065
+			public static int mtrl_tabs_ripple_color = 2131034213;
+			
+			// aapt resource value: 0x7F050067
+			public static int mtrl_textinput_default_box_stroke_color = 2131034215;
+			
+			// aapt resource value: 0x7F050068
+			public static int mtrl_textinput_disabled_color = 2131034216;
+			
+			// aapt resource value: 0x7F050069
+			public static int mtrl_textinput_filled_box_default_background_color = 2131034217;
+			
+			// aapt resource value: 0x7F05006A
+			public static int mtrl_textinput_hovered_box_stroke_color = 2131034218;
+			
+			// aapt resource value: 0x7F050066
+			public static int mtrl_text_btn_text_color_selector = 2131034214;
+			
+			// aapt resource value: 0x7F05006B
+			public static int notification_action_color_filter = 2131034219;
+			
+			// aapt resource value: 0x7F05006C
+			public static int notification_icon_bg_color = 2131034220;
+			
+			// aapt resource value: 0x7F05006D
+			public static int notification_material_background_media_default_color = 2131034221;
+			
+			// aapt resource value: 0x7F05006E
+			public static int primary_dark_material_dark = 2131034222;
+			
+			// aapt resource value: 0x7F05006F
+			public static int primary_dark_material_light = 2131034223;
+			
+			// aapt resource value: 0x7F050070
+			public static int primary_material_dark = 2131034224;
+			
+			// aapt resource value: 0x7F050071
+			public static int primary_material_light = 2131034225;
+			
+			// aapt resource value: 0x7F050072
+			public static int primary_text_default_material_dark = 2131034226;
+			
+			// aapt resource value: 0x7F050073
+			public static int primary_text_default_material_light = 2131034227;
+			
+			// aapt resource value: 0x7F050074
+			public static int primary_text_disabled_material_dark = 2131034228;
+			
+			// aapt resource value: 0x7F050075
+			public static int primary_text_disabled_material_light = 2131034229;
+			
+			// aapt resource value: 0x7F050076
+			public static int ripple_material_dark = 2131034230;
+			
+			// aapt resource value: 0x7F050077
+			public static int ripple_material_light = 2131034231;
+			
+			// aapt resource value: 0x7F050078
+			public static int secondary_text_default_material_dark = 2131034232;
+			
+			// aapt resource value: 0x7F050079
+			public static int secondary_text_default_material_light = 2131034233;
+			
+			// aapt resource value: 0x7F05007A
+			public static int secondary_text_disabled_material_dark = 2131034234;
+			
+			// aapt resource value: 0x7F05007B
+			public static int secondary_text_disabled_material_light = 2131034235;
+			
+			// aapt resource value: 0x7F05007C
+			public static int switch_thumb_disabled_material_dark = 2131034236;
+			
+			// aapt resource value: 0x7F05007D
+			public static int switch_thumb_disabled_material_light = 2131034237;
+			
+			// aapt resource value: 0x7F05007E
+			public static int switch_thumb_material_dark = 2131034238;
+			
+			// aapt resource value: 0x7F05007F
+			public static int switch_thumb_material_light = 2131034239;
+			
+			// aapt resource value: 0x7F050080
+			public static int switch_thumb_normal_material_dark = 2131034240;
+			
+			// aapt resource value: 0x7F050081
+			public static int switch_thumb_normal_material_light = 2131034241;
+			
+			// aapt resource value: 0x7F050082
+			public static int tooltip_background_dark = 2131034242;
+			
+			// aapt resource value: 0x7F050083
+			public static int tooltip_background_light = 2131034243;
+			
+			static Color()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Color()
+			{
+			}
+		}
+		
+		public partial class Dimension
+		{
+			
+			// aapt resource value: 0x7F060000
+			public static int abc_action_bar_content_inset_material = 2131099648;
+			
+			// aapt resource value: 0x7F060001
+			public static int abc_action_bar_content_inset_with_nav = 2131099649;
+			
+			// aapt resource value: 0x7F060002
+			public static int abc_action_bar_default_height_material = 2131099650;
+			
+			// aapt resource value: 0x7F060003
+			public static int abc_action_bar_default_padding_end_material = 2131099651;
+			
+			// aapt resource value: 0x7F060004
+			public static int abc_action_bar_default_padding_start_material = 2131099652;
+			
+			// aapt resource value: 0x7F060005
+			public static int abc_action_bar_elevation_material = 2131099653;
+			
+			// aapt resource value: 0x7F060006
+			public static int abc_action_bar_icon_vertical_padding_material = 2131099654;
+			
+			// aapt resource value: 0x7F060007
+			public static int abc_action_bar_overflow_padding_end_material = 2131099655;
+			
+			// aapt resource value: 0x7F060008
+			public static int abc_action_bar_overflow_padding_start_material = 2131099656;
+			
+			// aapt resource value: 0x7F060009
+			public static int abc_action_bar_stacked_max_height = 2131099657;
+			
+			// aapt resource value: 0x7F06000A
+			public static int abc_action_bar_stacked_tab_max_width = 2131099658;
+			
+			// aapt resource value: 0x7F06000B
+			public static int abc_action_bar_subtitle_bottom_margin_material = 2131099659;
+			
+			// aapt resource value: 0x7F06000C
+			public static int abc_action_bar_subtitle_top_margin_material = 2131099660;
+			
+			// aapt resource value: 0x7F06000D
+			public static int abc_action_button_min_height_material = 2131099661;
+			
+			// aapt resource value: 0x7F06000E
+			public static int abc_action_button_min_width_material = 2131099662;
+			
+			// aapt resource value: 0x7F06000F
+			public static int abc_action_button_min_width_overflow_material = 2131099663;
+			
+			// aapt resource value: 0x7F060010
+			public static int abc_alert_dialog_button_bar_height = 2131099664;
+			
+			// aapt resource value: 0x7F060011
+			public static int abc_alert_dialog_button_dimen = 2131099665;
+			
+			// aapt resource value: 0x7F060012
+			public static int abc_button_inset_horizontal_material = 2131099666;
+			
+			// aapt resource value: 0x7F060013
+			public static int abc_button_inset_vertical_material = 2131099667;
+			
+			// aapt resource value: 0x7F060014
+			public static int abc_button_padding_horizontal_material = 2131099668;
+			
+			// aapt resource value: 0x7F060015
+			public static int abc_button_padding_vertical_material = 2131099669;
+			
+			// aapt resource value: 0x7F060016
+			public static int abc_cascading_menus_min_smallest_width = 2131099670;
+			
+			// aapt resource value: 0x7F060017
+			public static int abc_config_prefDialogWidth = 2131099671;
+			
+			// aapt resource value: 0x7F060018
+			public static int abc_control_corner_material = 2131099672;
+			
+			// aapt resource value: 0x7F060019
+			public static int abc_control_inset_material = 2131099673;
+			
+			// aapt resource value: 0x7F06001A
+			public static int abc_control_padding_material = 2131099674;
+			
+			// aapt resource value: 0x7F06001B
+			public static int abc_dialog_corner_radius_material = 2131099675;
+			
+			// aapt resource value: 0x7F06001C
+			public static int abc_dialog_fixed_height_major = 2131099676;
+			
+			// aapt resource value: 0x7F06001D
+			public static int abc_dialog_fixed_height_minor = 2131099677;
+			
+			// aapt resource value: 0x7F06001E
+			public static int abc_dialog_fixed_width_major = 2131099678;
+			
+			// aapt resource value: 0x7F06001F
+			public static int abc_dialog_fixed_width_minor = 2131099679;
+			
+			// aapt resource value: 0x7F060020
+			public static int abc_dialog_list_padding_bottom_no_buttons = 2131099680;
+			
+			// aapt resource value: 0x7F060021
+			public static int abc_dialog_list_padding_top_no_title = 2131099681;
+			
+			// aapt resource value: 0x7F060022
+			public static int abc_dialog_min_width_major = 2131099682;
+			
+			// aapt resource value: 0x7F060023
+			public static int abc_dialog_min_width_minor = 2131099683;
+			
+			// aapt resource value: 0x7F060024
+			public static int abc_dialog_padding_material = 2131099684;
+			
+			// aapt resource value: 0x7F060025
+			public static int abc_dialog_padding_top_material = 2131099685;
+			
+			// aapt resource value: 0x7F060026
+			public static int abc_dialog_title_divider_material = 2131099686;
+			
+			// aapt resource value: 0x7F060027
+			public static int abc_disabled_alpha_material_dark = 2131099687;
+			
+			// aapt resource value: 0x7F060028
+			public static int abc_disabled_alpha_material_light = 2131099688;
+			
+			// aapt resource value: 0x7F060029
+			public static int abc_dropdownitem_icon_width = 2131099689;
+			
+			// aapt resource value: 0x7F06002A
+			public static int abc_dropdownitem_text_padding_left = 2131099690;
+			
+			// aapt resource value: 0x7F06002B
+			public static int abc_dropdownitem_text_padding_right = 2131099691;
+			
+			// aapt resource value: 0x7F06002C
+			public static int abc_edit_text_inset_bottom_material = 2131099692;
+			
+			// aapt resource value: 0x7F06002D
+			public static int abc_edit_text_inset_horizontal_material = 2131099693;
+			
+			// aapt resource value: 0x7F06002E
+			public static int abc_edit_text_inset_top_material = 2131099694;
+			
+			// aapt resource value: 0x7F06002F
+			public static int abc_floating_window_z = 2131099695;
+			
+			// aapt resource value: 0x7F060030
+			public static int abc_list_item_padding_horizontal_material = 2131099696;
+			
+			// aapt resource value: 0x7F060031
+			public static int abc_panel_menu_list_width = 2131099697;
+			
+			// aapt resource value: 0x7F060032
+			public static int abc_progress_bar_height_material = 2131099698;
+			
+			// aapt resource value: 0x7F060033
+			public static int abc_search_view_preferred_height = 2131099699;
+			
+			// aapt resource value: 0x7F060034
+			public static int abc_search_view_preferred_width = 2131099700;
+			
+			// aapt resource value: 0x7F060035
+			public static int abc_seekbar_track_background_height_material = 2131099701;
+			
+			// aapt resource value: 0x7F060036
+			public static int abc_seekbar_track_progress_height_material = 2131099702;
+			
+			// aapt resource value: 0x7F060037
+			public static int abc_select_dialog_padding_start_material = 2131099703;
+			
+			// aapt resource value: 0x7F060038
+			public static int abc_switch_padding = 2131099704;
+			
+			// aapt resource value: 0x7F060039
+			public static int abc_text_size_body_1_material = 2131099705;
+			
+			// aapt resource value: 0x7F06003A
+			public static int abc_text_size_body_2_material = 2131099706;
+			
+			// aapt resource value: 0x7F06003B
+			public static int abc_text_size_button_material = 2131099707;
+			
+			// aapt resource value: 0x7F06003C
+			public static int abc_text_size_caption_material = 2131099708;
+			
+			// aapt resource value: 0x7F06003D
+			public static int abc_text_size_display_1_material = 2131099709;
+			
+			// aapt resource value: 0x7F06003E
+			public static int abc_text_size_display_2_material = 2131099710;
+			
+			// aapt resource value: 0x7F06003F
+			public static int abc_text_size_display_3_material = 2131099711;
+			
+			// aapt resource value: 0x7F060040
+			public static int abc_text_size_display_4_material = 2131099712;
+			
+			// aapt resource value: 0x7F060041
+			public static int abc_text_size_headline_material = 2131099713;
+			
+			// aapt resource value: 0x7F060042
+			public static int abc_text_size_large_material = 2131099714;
+			
+			// aapt resource value: 0x7F060043
+			public static int abc_text_size_medium_material = 2131099715;
+			
+			// aapt resource value: 0x7F060044
+			public static int abc_text_size_menu_header_material = 2131099716;
+			
+			// aapt resource value: 0x7F060045
+			public static int abc_text_size_menu_material = 2131099717;
+			
+			// aapt resource value: 0x7F060046
+			public static int abc_text_size_small_material = 2131099718;
+			
+			// aapt resource value: 0x7F060047
+			public static int abc_text_size_subhead_material = 2131099719;
+			
+			// aapt resource value: 0x7F060048
+			public static int abc_text_size_subtitle_material_toolbar = 2131099720;
+			
+			// aapt resource value: 0x7F060049
+			public static int abc_text_size_title_material = 2131099721;
+			
+			// aapt resource value: 0x7F06004A
+			public static int abc_text_size_title_material_toolbar = 2131099722;
+			
+			// aapt resource value: 0x7F06004B
+			public static int browser_actions_context_menu_max_width = 2131099723;
+			
+			// aapt resource value: 0x7F06004C
+			public static int browser_actions_context_menu_min_padding = 2131099724;
+			
+			// aapt resource value: 0x7F06004D
+			public static int cardview_compat_inset_shadow = 2131099725;
+			
+			// aapt resource value: 0x7F06004E
+			public static int cardview_default_elevation = 2131099726;
+			
+			// aapt resource value: 0x7F06004F
+			public static int cardview_default_radius = 2131099727;
+			
+			// aapt resource value: 0x7F060050
+			public static int compat_button_inset_horizontal_material = 2131099728;
+			
+			// aapt resource value: 0x7F060051
+			public static int compat_button_inset_vertical_material = 2131099729;
+			
+			// aapt resource value: 0x7F060052
+			public static int compat_button_padding_horizontal_material = 2131099730;
+			
+			// aapt resource value: 0x7F060053
+			public static int compat_button_padding_vertical_material = 2131099731;
+			
+			// aapt resource value: 0x7F060054
+			public static int compat_control_corner_material = 2131099732;
+			
+			// aapt resource value: 0x7F060055
+			public static int compat_notification_large_icon_max_height = 2131099733;
+			
+			// aapt resource value: 0x7F060056
+			public static int compat_notification_large_icon_max_width = 2131099734;
+			
+			// aapt resource value: 0x7F060057
+			public static int design_appbar_elevation = 2131099735;
+			
+			// aapt resource value: 0x7F060058
+			public static int design_bottom_navigation_active_item_max_width = 2131099736;
+			
+			// aapt resource value: 0x7F060059
+			public static int design_bottom_navigation_active_item_min_width = 2131099737;
+			
+			// aapt resource value: 0x7F06005A
+			public static int design_bottom_navigation_active_text_size = 2131099738;
+			
+			// aapt resource value: 0x7F06005B
+			public static int design_bottom_navigation_elevation = 2131099739;
+			
+			// aapt resource value: 0x7F06005C
+			public static int design_bottom_navigation_height = 2131099740;
+			
+			// aapt resource value: 0x7F06005D
+			public static int design_bottom_navigation_icon_size = 2131099741;
+			
+			// aapt resource value: 0x7F06005E
+			public static int design_bottom_navigation_item_max_width = 2131099742;
+			
+			// aapt resource value: 0x7F06005F
+			public static int design_bottom_navigation_item_min_width = 2131099743;
+			
+			// aapt resource value: 0x7F060060
+			public static int design_bottom_navigation_margin = 2131099744;
+			
+			// aapt resource value: 0x7F060061
+			public static int design_bottom_navigation_shadow_height = 2131099745;
+			
+			// aapt resource value: 0x7F060062
+			public static int design_bottom_navigation_text_size = 2131099746;
+			
+			// aapt resource value: 0x7F060063
+			public static int design_bottom_sheet_modal_elevation = 2131099747;
+			
+			// aapt resource value: 0x7F060064
+			public static int design_bottom_sheet_peek_height_min = 2131099748;
+			
+			// aapt resource value: 0x7F060065
+			public static int design_fab_border_width = 2131099749;
+			
+			// aapt resource value: 0x7F060066
+			public static int design_fab_elevation = 2131099750;
+			
+			// aapt resource value: 0x7F060067
+			public static int design_fab_image_size = 2131099751;
+			
+			// aapt resource value: 0x7F060068
+			public static int design_fab_size_mini = 2131099752;
+			
+			// aapt resource value: 0x7F060069
+			public static int design_fab_size_normal = 2131099753;
+			
+			// aapt resource value: 0x7F06006A
+			public static int design_fab_translation_z_hovered_focused = 2131099754;
+			
+			// aapt resource value: 0x7F06006B
+			public static int design_fab_translation_z_pressed = 2131099755;
+			
+			// aapt resource value: 0x7F06006C
+			public static int design_navigation_elevation = 2131099756;
+			
+			// aapt resource value: 0x7F06006D
+			public static int design_navigation_icon_padding = 2131099757;
+			
+			// aapt resource value: 0x7F06006E
+			public static int design_navigation_icon_size = 2131099758;
+			
+			// aapt resource value: 0x7F06006F
+			public static int design_navigation_item_horizontal_padding = 2131099759;
+			
+			// aapt resource value: 0x7F060070
+			public static int design_navigation_item_icon_padding = 2131099760;
+			
+			// aapt resource value: 0x7F060071
+			public static int design_navigation_max_width = 2131099761;
+			
+			// aapt resource value: 0x7F060072
+			public static int design_navigation_padding_bottom = 2131099762;
+			
+			// aapt resource value: 0x7F060073
+			public static int design_navigation_separator_vertical_padding = 2131099763;
+			
+			// aapt resource value: 0x7F060074
+			public static int design_snackbar_action_inline_max_width = 2131099764;
+			
+			// aapt resource value: 0x7F060075
+			public static int design_snackbar_background_corner_radius = 2131099765;
+			
+			// aapt resource value: 0x7F060076
+			public static int design_snackbar_elevation = 2131099766;
+			
+			// aapt resource value: 0x7F060077
+			public static int design_snackbar_extra_spacing_horizontal = 2131099767;
+			
+			// aapt resource value: 0x7F060078
+			public static int design_snackbar_max_width = 2131099768;
+			
+			// aapt resource value: 0x7F060079
+			public static int design_snackbar_min_width = 2131099769;
+			
+			// aapt resource value: 0x7F06007A
+			public static int design_snackbar_padding_horizontal = 2131099770;
+			
+			// aapt resource value: 0x7F06007B
+			public static int design_snackbar_padding_vertical = 2131099771;
+			
+			// aapt resource value: 0x7F06007C
+			public static int design_snackbar_padding_vertical_2lines = 2131099772;
+			
+			// aapt resource value: 0x7F06007D
+			public static int design_snackbar_text_size = 2131099773;
+			
+			// aapt resource value: 0x7F06007E
+			public static int design_tab_max_width = 2131099774;
+			
+			// aapt resource value: 0x7F06007F
+			public static int design_tab_scrollable_min_width = 2131099775;
+			
+			// aapt resource value: 0x7F060080
+			public static int design_tab_text_size = 2131099776;
+			
+			// aapt resource value: 0x7F060081
+			public static int design_tab_text_size_2line = 2131099777;
+			
+			// aapt resource value: 0x7F060082
+			public static int design_textinput_caption_translate_y = 2131099778;
+			
+			// aapt resource value: 0x7F060083
+			public static int disabled_alpha_material_dark = 2131099779;
+			
+			// aapt resource value: 0x7F060084
+			public static int disabled_alpha_material_light = 2131099780;
+			
+			// aapt resource value: 0x7F060085
+			public static int fastscroll_default_thickness = 2131099781;
+			
+			// aapt resource value: 0x7F060086
+			public static int fastscroll_margin = 2131099782;
+			
+			// aapt resource value: 0x7F060087
+			public static int fastscroll_minimum_range = 2131099783;
+			
+			// aapt resource value: 0x7F060088
+			public static int highlight_alpha_material_colored = 2131099784;
+			
+			// aapt resource value: 0x7F060089
+			public static int highlight_alpha_material_dark = 2131099785;
+			
+			// aapt resource value: 0x7F06008A
+			public static int highlight_alpha_material_light = 2131099786;
+			
+			// aapt resource value: 0x7F06008B
+			public static int hint_alpha_material_dark = 2131099787;
+			
+			// aapt resource value: 0x7F06008C
+			public static int hint_alpha_material_light = 2131099788;
+			
+			// aapt resource value: 0x7F06008D
+			public static int hint_pressed_alpha_material_dark = 2131099789;
+			
+			// aapt resource value: 0x7F06008E
+			public static int hint_pressed_alpha_material_light = 2131099790;
+			
+			// aapt resource value: 0x7F06008F
+			public static int item_touch_helper_max_drag_scroll_per_frame = 2131099791;
+			
+			// aapt resource value: 0x7F060090
+			public static int item_touch_helper_swipe_escape_max_velocity = 2131099792;
+			
+			// aapt resource value: 0x7F060091
+			public static int item_touch_helper_swipe_escape_velocity = 2131099793;
+			
+			// aapt resource value: 0x7F060092
+			public static int mtrl_bottomappbar_fabOffsetEndMode = 2131099794;
+			
+			// aapt resource value: 0x7F060093
+			public static int mtrl_bottomappbar_fab_cradle_margin = 2131099795;
+			
+			// aapt resource value: 0x7F060094
+			public static int mtrl_bottomappbar_fab_cradle_rounded_corner_radius = 2131099796;
+			
+			// aapt resource value: 0x7F060095
+			public static int mtrl_bottomappbar_fab_cradle_vertical_offset = 2131099797;
+			
+			// aapt resource value: 0x7F060096
+			public static int mtrl_bottomappbar_height = 2131099798;
+			
+			// aapt resource value: 0x7F060097
+			public static int mtrl_btn_corner_radius = 2131099799;
+			
+			// aapt resource value: 0x7F060098
+			public static int mtrl_btn_dialog_btn_min_width = 2131099800;
+			
+			// aapt resource value: 0x7F060099
+			public static int mtrl_btn_disabled_elevation = 2131099801;
+			
+			// aapt resource value: 0x7F06009A
+			public static int mtrl_btn_disabled_z = 2131099802;
+			
+			// aapt resource value: 0x7F06009B
+			public static int mtrl_btn_elevation = 2131099803;
+			
+			// aapt resource value: 0x7F06009C
+			public static int mtrl_btn_focused_z = 2131099804;
+			
+			// aapt resource value: 0x7F06009D
+			public static int mtrl_btn_hovered_z = 2131099805;
+			
+			// aapt resource value: 0x7F06009E
+			public static int mtrl_btn_icon_btn_padding_left = 2131099806;
+			
+			// aapt resource value: 0x7F06009F
+			public static int mtrl_btn_icon_padding = 2131099807;
+			
+			// aapt resource value: 0x7F0600A0
+			public static int mtrl_btn_inset = 2131099808;
+			
+			// aapt resource value: 0x7F0600A1
+			public static int mtrl_btn_letter_spacing = 2131099809;
+			
+			// aapt resource value: 0x7F0600A2
+			public static int mtrl_btn_padding_bottom = 2131099810;
+			
+			// aapt resource value: 0x7F0600A3
+			public static int mtrl_btn_padding_left = 2131099811;
+			
+			// aapt resource value: 0x7F0600A4
+			public static int mtrl_btn_padding_right = 2131099812;
+			
+			// aapt resource value: 0x7F0600A5
+			public static int mtrl_btn_padding_top = 2131099813;
+			
+			// aapt resource value: 0x7F0600A6
+			public static int mtrl_btn_pressed_z = 2131099814;
+			
+			// aapt resource value: 0x7F0600A7
+			public static int mtrl_btn_stroke_size = 2131099815;
+			
+			// aapt resource value: 0x7F0600A8
+			public static int mtrl_btn_text_btn_icon_padding = 2131099816;
+			
+			// aapt resource value: 0x7F0600A9
+			public static int mtrl_btn_text_btn_padding_left = 2131099817;
+			
+			// aapt resource value: 0x7F0600AA
+			public static int mtrl_btn_text_btn_padding_right = 2131099818;
+			
+			// aapt resource value: 0x7F0600AB
+			public static int mtrl_btn_text_size = 2131099819;
+			
+			// aapt resource value: 0x7F0600AC
+			public static int mtrl_btn_z = 2131099820;
+			
+			// aapt resource value: 0x7F0600AD
+			public static int mtrl_card_elevation = 2131099821;
+			
+			// aapt resource value: 0x7F0600AE
+			public static int mtrl_card_spacing = 2131099822;
+			
+			// aapt resource value: 0x7F0600AF
+			public static int mtrl_chip_pressed_translation_z = 2131099823;
+			
+			// aapt resource value: 0x7F0600B0
+			public static int mtrl_chip_text_size = 2131099824;
+			
+			// aapt resource value: 0x7F0600B1
+			public static int mtrl_fab_elevation = 2131099825;
+			
+			// aapt resource value: 0x7F0600B2
+			public static int mtrl_fab_translation_z_hovered_focused = 2131099826;
+			
+			// aapt resource value: 0x7F0600B3
+			public static int mtrl_fab_translation_z_pressed = 2131099827;
+			
+			// aapt resource value: 0x7F0600B4
+			public static int mtrl_navigation_elevation = 2131099828;
+			
+			// aapt resource value: 0x7F0600B5
+			public static int mtrl_navigation_item_horizontal_padding = 2131099829;
+			
+			// aapt resource value: 0x7F0600B6
+			public static int mtrl_navigation_item_icon_padding = 2131099830;
+			
+			// aapt resource value: 0x7F0600B7
+			public static int mtrl_snackbar_background_corner_radius = 2131099831;
+			
+			// aapt resource value: 0x7F0600B8
+			public static int mtrl_snackbar_margin = 2131099832;
+			
+			// aapt resource value: 0x7F0600B9
+			public static int mtrl_textinput_box_bottom_offset = 2131099833;
+			
+			// aapt resource value: 0x7F0600BA
+			public static int mtrl_textinput_box_corner_radius_medium = 2131099834;
+			
+			// aapt resource value: 0x7F0600BB
+			public static int mtrl_textinput_box_corner_radius_small = 2131099835;
+			
+			// aapt resource value: 0x7F0600BC
+			public static int mtrl_textinput_box_label_cutout_padding = 2131099836;
+			
+			// aapt resource value: 0x7F0600BD
+			public static int mtrl_textinput_box_padding_end = 2131099837;
+			
+			// aapt resource value: 0x7F0600BE
+			public static int mtrl_textinput_box_stroke_width_default = 2131099838;
+			
+			// aapt resource value: 0x7F0600BF
+			public static int mtrl_textinput_box_stroke_width_focused = 2131099839;
+			
+			// aapt resource value: 0x7F0600C0
+			public static int mtrl_textinput_outline_box_expanded_padding = 2131099840;
+			
+			// aapt resource value: 0x7F0600C1
+			public static int mtrl_toolbar_default_height = 2131099841;
+			
+			// aapt resource value: 0x7F0600C2
+			public static int notification_action_icon_size = 2131099842;
+			
+			// aapt resource value: 0x7F0600C3
+			public static int notification_action_text_size = 2131099843;
+			
+			// aapt resource value: 0x7F0600C4
+			public static int notification_big_circle_margin = 2131099844;
+			
+			// aapt resource value: 0x7F0600C5
+			public static int notification_content_margin_start = 2131099845;
+			
+			// aapt resource value: 0x7F0600C6
+			public static int notification_large_icon_height = 2131099846;
+			
+			// aapt resource value: 0x7F0600C7
+			public static int notification_large_icon_width = 2131099847;
+			
+			// aapt resource value: 0x7F0600C8
+			public static int notification_main_column_padding_top = 2131099848;
+			
+			// aapt resource value: 0x7F0600C9
+			public static int notification_media_narrow_margin = 2131099849;
+			
+			// aapt resource value: 0x7F0600CA
+			public static int notification_right_icon_size = 2131099850;
+			
+			// aapt resource value: 0x7F0600CB
+			public static int notification_right_side_padding_top = 2131099851;
+			
+			// aapt resource value: 0x7F0600CC
+			public static int notification_small_icon_background_padding = 2131099852;
+			
+			// aapt resource value: 0x7F0600CD
+			public static int notification_small_icon_size_as_large = 2131099853;
+			
+			// aapt resource value: 0x7F0600CE
+			public static int notification_subtext_size = 2131099854;
+			
+			// aapt resource value: 0x7F0600CF
+			public static int notification_top_pad = 2131099855;
+			
+			// aapt resource value: 0x7F0600D0
+			public static int notification_top_pad_large_text = 2131099856;
+			
+			// aapt resource value: 0x7F0600D1
+			public static int subtitle_corner_radius = 2131099857;
+			
+			// aapt resource value: 0x7F0600D2
+			public static int subtitle_outline_width = 2131099858;
+			
+			// aapt resource value: 0x7F0600D3
+			public static int subtitle_shadow_offset = 2131099859;
+			
+			// aapt resource value: 0x7F0600D4
+			public static int subtitle_shadow_radius = 2131099860;
+			
+			// aapt resource value: 0x7F0600D5
+			public static int tooltip_corner_radius = 2131099861;
+			
+			// aapt resource value: 0x7F0600D6
+			public static int tooltip_horizontal_padding = 2131099862;
+			
+			// aapt resource value: 0x7F0600D7
+			public static int tooltip_margin = 2131099863;
+			
+			// aapt resource value: 0x7F0600D8
+			public static int tooltip_precise_anchor_extra_offset = 2131099864;
+			
+			// aapt resource value: 0x7F0600D9
+			public static int tooltip_precise_anchor_threshold = 2131099865;
+			
+			// aapt resource value: 0x7F0600DA
+			public static int tooltip_vertical_padding = 2131099866;
+			
+			// aapt resource value: 0x7F0600DB
+			public static int tooltip_y_offset_non_touch = 2131099867;
+			
+			// aapt resource value: 0x7F0600DC
+			public static int tooltip_y_offset_touch = 2131099868;
+			
+			static Dimension()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Dimension()
+			{
+			}
+		}
+		
+		public partial class Drawable
+		{
+			
+			// aapt resource value: 0x7F070006
+			public static int abc_ab_share_pack_mtrl_alpha = 2131165190;
+			
+			// aapt resource value: 0x7F070007
+			public static int abc_action_bar_item_background_material = 2131165191;
+			
+			// aapt resource value: 0x7F070008
+			public static int abc_btn_borderless_material = 2131165192;
+			
+			// aapt resource value: 0x7F070009
+			public static int abc_btn_check_material = 2131165193;
+			
+			// aapt resource value: 0x7F07000A
+			public static int abc_btn_check_to_on_mtrl_000 = 2131165194;
+			
+			// aapt resource value: 0x7F07000B
+			public static int abc_btn_check_to_on_mtrl_015 = 2131165195;
+			
+			// aapt resource value: 0x7F07000C
+			public static int abc_btn_colored_material = 2131165196;
+			
+			// aapt resource value: 0x7F07000D
+			public static int abc_btn_default_mtrl_shape = 2131165197;
+			
+			// aapt resource value: 0x7F07000E
+			public static int abc_btn_radio_material = 2131165198;
+			
+			// aapt resource value: 0x7F07000F
+			public static int abc_btn_radio_to_on_mtrl_000 = 2131165199;
+			
+			// aapt resource value: 0x7F070010
+			public static int abc_btn_radio_to_on_mtrl_015 = 2131165200;
+			
+			// aapt resource value: 0x7F070011
+			public static int abc_btn_switch_to_on_mtrl_00001 = 2131165201;
+			
+			// aapt resource value: 0x7F070012
+			public static int abc_btn_switch_to_on_mtrl_00012 = 2131165202;
+			
+			// aapt resource value: 0x7F070013
+			public static int abc_cab_background_internal_bg = 2131165203;
+			
+			// aapt resource value: 0x7F070014
+			public static int abc_cab_background_top_material = 2131165204;
+			
+			// aapt resource value: 0x7F070015
+			public static int abc_cab_background_top_mtrl_alpha = 2131165205;
+			
+			// aapt resource value: 0x7F070016
+			public static int abc_control_background_material = 2131165206;
+			
+			// aapt resource value: 0x7F070017
+			public static int abc_dialog_material_background = 2131165207;
+			
+			// aapt resource value: 0x7F070018
+			public static int abc_edit_text_material = 2131165208;
+			
+			// aapt resource value: 0x7F070019
+			public static int abc_ic_ab_back_material = 2131165209;
+			
+			// aapt resource value: 0x7F07001A
+			public static int abc_ic_arrow_drop_right_black_24dp = 2131165210;
+			
+			// aapt resource value: 0x7F07001B
+			public static int abc_ic_clear_material = 2131165211;
+			
+			// aapt resource value: 0x7F07001C
+			public static int abc_ic_commit_search_api_mtrl_alpha = 2131165212;
+			
+			// aapt resource value: 0x7F07001D
+			public static int abc_ic_go_search_api_material = 2131165213;
+			
+			// aapt resource value: 0x7F07001E
+			public static int abc_ic_menu_copy_mtrl_am_alpha = 2131165214;
+			
+			// aapt resource value: 0x7F07001F
+			public static int abc_ic_menu_cut_mtrl_alpha = 2131165215;
+			
+			// aapt resource value: 0x7F070020
+			public static int abc_ic_menu_overflow_material = 2131165216;
+			
+			// aapt resource value: 0x7F070021
+			public static int abc_ic_menu_paste_mtrl_am_alpha = 2131165217;
+			
+			// aapt resource value: 0x7F070022
+			public static int abc_ic_menu_selectall_mtrl_alpha = 2131165218;
+			
+			// aapt resource value: 0x7F070023
+			public static int abc_ic_menu_share_mtrl_alpha = 2131165219;
+			
+			// aapt resource value: 0x7F070024
+			public static int abc_ic_search_api_material = 2131165220;
+			
+			// aapt resource value: 0x7F070025
+			public static int abc_ic_star_black_16dp = 2131165221;
+			
+			// aapt resource value: 0x7F070026
+			public static int abc_ic_star_black_36dp = 2131165222;
+			
+			// aapt resource value: 0x7F070027
+			public static int abc_ic_star_black_48dp = 2131165223;
+			
+			// aapt resource value: 0x7F070028
+			public static int abc_ic_star_half_black_16dp = 2131165224;
+			
+			// aapt resource value: 0x7F070029
+			public static int abc_ic_star_half_black_36dp = 2131165225;
+			
+			// aapt resource value: 0x7F07002A
+			public static int abc_ic_star_half_black_48dp = 2131165226;
+			
+			// aapt resource value: 0x7F07002B
+			public static int abc_ic_voice_search_api_material = 2131165227;
+			
+			// aapt resource value: 0x7F07002C
+			public static int abc_item_background_holo_dark = 2131165228;
+			
+			// aapt resource value: 0x7F07002D
+			public static int abc_item_background_holo_light = 2131165229;
+			
+			// aapt resource value: 0x7F07002E
+			public static int abc_list_divider_material = 2131165230;
+			
+			// aapt resource value: 0x7F07002F
+			public static int abc_list_divider_mtrl_alpha = 2131165231;
+			
+			// aapt resource value: 0x7F070030
+			public static int abc_list_focused_holo = 2131165232;
+			
+			// aapt resource value: 0x7F070031
+			public static int abc_list_longpressed_holo = 2131165233;
+			
+			// aapt resource value: 0x7F070032
+			public static int abc_list_pressed_holo_dark = 2131165234;
+			
+			// aapt resource value: 0x7F070033
+			public static int abc_list_pressed_holo_light = 2131165235;
+			
+			// aapt resource value: 0x7F070034
+			public static int abc_list_selector_background_transition_holo_dark = 2131165236;
+			
+			// aapt resource value: 0x7F070035
+			public static int abc_list_selector_background_transition_holo_light = 2131165237;
+			
+			// aapt resource value: 0x7F070036
+			public static int abc_list_selector_disabled_holo_dark = 2131165238;
+			
+			// aapt resource value: 0x7F070037
+			public static int abc_list_selector_disabled_holo_light = 2131165239;
+			
+			// aapt resource value: 0x7F070038
+			public static int abc_list_selector_holo_dark = 2131165240;
+			
+			// aapt resource value: 0x7F070039
+			public static int abc_list_selector_holo_light = 2131165241;
+			
+			// aapt resource value: 0x7F07003A
+			public static int abc_menu_hardkey_panel_mtrl_mult = 2131165242;
+			
+			// aapt resource value: 0x7F07003B
+			public static int abc_popup_background_mtrl_mult = 2131165243;
+			
+			// aapt resource value: 0x7F07003C
+			public static int abc_ratingbar_indicator_material = 2131165244;
+			
+			// aapt resource value: 0x7F07003D
+			public static int abc_ratingbar_material = 2131165245;
+			
+			// aapt resource value: 0x7F07003E
+			public static int abc_ratingbar_small_material = 2131165246;
+			
+			// aapt resource value: 0x7F07003F
+			public static int abc_scrubber_control_off_mtrl_alpha = 2131165247;
+			
+			// aapt resource value: 0x7F070040
+			public static int abc_scrubber_control_to_pressed_mtrl_000 = 2131165248;
+			
+			// aapt resource value: 0x7F070041
+			public static int abc_scrubber_control_to_pressed_mtrl_005 = 2131165249;
+			
+			// aapt resource value: 0x7F070042
+			public static int abc_scrubber_primary_mtrl_alpha = 2131165250;
+			
+			// aapt resource value: 0x7F070043
+			public static int abc_scrubber_track_mtrl_alpha = 2131165251;
+			
+			// aapt resource value: 0x7F070044
+			public static int abc_seekbar_thumb_material = 2131165252;
+			
+			// aapt resource value: 0x7F070045
+			public static int abc_seekbar_tick_mark_material = 2131165253;
+			
+			// aapt resource value: 0x7F070046
+			public static int abc_seekbar_track_material = 2131165254;
+			
+			// aapt resource value: 0x7F070047
+			public static int abc_spinner_mtrl_am_alpha = 2131165255;
+			
+			// aapt resource value: 0x7F070048
+			public static int abc_spinner_textfield_background_material = 2131165256;
+			
+			// aapt resource value: 0x7F070049
+			public static int abc_switch_thumb_material = 2131165257;
+			
+			// aapt resource value: 0x7F07004A
+			public static int abc_switch_track_mtrl_alpha = 2131165258;
+			
+			// aapt resource value: 0x7F07004B
+			public static int abc_tab_indicator_material = 2131165259;
+			
+			// aapt resource value: 0x7F07004C
+			public static int abc_tab_indicator_mtrl_alpha = 2131165260;
+			
+			// aapt resource value: 0x7F070054
+			public static int abc_textfield_activated_mtrl_alpha = 2131165268;
+			
+			// aapt resource value: 0x7F070055
+			public static int abc_textfield_default_mtrl_alpha = 2131165269;
+			
+			// aapt resource value: 0x7F070056
+			public static int abc_textfield_search_activated_mtrl_alpha = 2131165270;
+			
+			// aapt resource value: 0x7F070057
+			public static int abc_textfield_search_default_mtrl_alpha = 2131165271;
+			
+			// aapt resource value: 0x7F070058
+			public static int abc_textfield_search_material = 2131165272;
+			
+			// aapt resource value: 0x7F07004D
+			public static int abc_text_cursor_material = 2131165261;
+			
+			// aapt resource value: 0x7F07004E
+			public static int abc_text_select_handle_left_mtrl_dark = 2131165262;
+			
+			// aapt resource value: 0x7F07004F
+			public static int abc_text_select_handle_left_mtrl_light = 2131165263;
+			
+			// aapt resource value: 0x7F070050
+			public static int abc_text_select_handle_middle_mtrl_dark = 2131165264;
+			
+			// aapt resource value: 0x7F070051
+			public static int abc_text_select_handle_middle_mtrl_light = 2131165265;
+			
+			// aapt resource value: 0x7F070052
+			public static int abc_text_select_handle_right_mtrl_dark = 2131165266;
+			
+			// aapt resource value: 0x7F070053
+			public static int abc_text_select_handle_right_mtrl_light = 2131165267;
+			
+			// aapt resource value: 0x7F070059
+			public static int abc_vector_test = 2131165273;
+			
+			// aapt resource value: 0x7F07005A
+			public static int avd_hide_password = 2131165274;
+			
+			// aapt resource value: 0x7F07005B
+			public static int avd_show_password = 2131165275;
+			
+			// aapt resource value: 0x7F07005C
+			public static int design_bottom_navigation_item_background = 2131165276;
+			
+			// aapt resource value: 0x7F07005D
+			public static int design_fab_background = 2131165277;
+			
+			// aapt resource value: 0x7F07005E
+			public static int design_ic_visibility = 2131165278;
+			
+			// aapt resource value: 0x7F07005F
+			public static int design_ic_visibility_off = 2131165279;
+			
+			// aapt resource value: 0x7F070060
+			public static int design_password_eye = 2131165280;
+			
+			// aapt resource value: 0x7F070061
+			public static int design_snackbar_background = 2131165281;
+			
+			// aapt resource value: 0x7F070062
+			public static int ic_mtrl_chip_checked_black = 2131165282;
+			
+			// aapt resource value: 0x7F070063
+			public static int ic_mtrl_chip_checked_circle = 2131165283;
+			
+			// aapt resource value: 0x7F070064
+			public static int ic_mtrl_chip_close_circle = 2131165284;
+			
+			// aapt resource value: 0x7F070065
+			public static int mtrl_snackbar_background = 2131165285;
+			
+			// aapt resource value: 0x7F070066
+			public static int mtrl_tabs_default_indicator = 2131165286;
+			
+			// aapt resource value: 0x7F070067
+			public static int navigation_empty_icon = 2131165287;
+			
+			// aapt resource value: 0x7F070068
+			public static int notification_action_background = 2131165288;
+			
+			// aapt resource value: 0x7F070069
+			public static int notification_bg = 2131165289;
+			
+			// aapt resource value: 0x7F07006A
+			public static int notification_bg_low = 2131165290;
+			
+			// aapt resource value: 0x7F07006B
+			public static int notification_bg_low_normal = 2131165291;
+			
+			// aapt resource value: 0x7F07006C
+			public static int notification_bg_low_pressed = 2131165292;
+			
+			// aapt resource value: 0x7F07006D
+			public static int notification_bg_normal = 2131165293;
+			
+			// aapt resource value: 0x7F07006E
+			public static int notification_bg_normal_pressed = 2131165294;
+			
+			// aapt resource value: 0x7F07006F
+			public static int notification_icon_background = 2131165295;
+			
+			// aapt resource value: 0x7F070070
+			public static int notification_template_icon_bg = 2131165296;
+			
+			// aapt resource value: 0x7F070071
+			public static int notification_template_icon_low_bg = 2131165297;
+			
+			// aapt resource value: 0x7F070072
+			public static int notification_tile_bg = 2131165298;
+			
+			// aapt resource value: 0x7F070073
+			public static int notify_panel_notification_icon_bg = 2131165299;
+			
+			// aapt resource value: 0x7F070074
+			public static int tooltip_frame_dark = 2131165300;
+			
+			// aapt resource value: 0x7F070075
+			public static int tooltip_frame_light = 2131165301;
 			
 			static Drawable()
 			{
@@ -254,125 +3046,620 @@ namespace AirshipBindings.NETStandard
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7F060000
-			public static int always_allow = 2131099648;
+			// aapt resource value: 0x7F080006
+			public static int action0 = 2131230726;
 			
-			// aapt resource value: 0x7F060001
-			public static int banner = 2131099649;
+			// aapt resource value: 0x7F080018
+			public static int actions = 2131230744;
 			
-			// aapt resource value: 0x7F060002
-			public static int banner_content = 2131099650;
+			// aapt resource value: 0x7F080007
+			public static int action_bar = 2131230727;
 			
-			// aapt resource value: 0x7F060003
-			public static int banner_pull = 2131099651;
+			// aapt resource value: 0x7F080008
+			public static int action_bar_activity_content = 2131230728;
 			
-			// aapt resource value: 0x7F060004
-			public static int body = 2131099652;
+			// aapt resource value: 0x7F080009
+			public static int action_bar_container = 2131230729;
 			
-			// aapt resource value: 0x7F060005
-			public static int buttons = 2131099653;
+			// aapt resource value: 0x7F08000A
+			public static int action_bar_root = 2131230730;
 			
-			// aapt resource value: 0x7F060006
-			public static int channel_capture_title = 2131099654;
+			// aapt resource value: 0x7F08000B
+			public static int action_bar_spinner = 2131230731;
 			
-			// aapt resource value: 0x7F060007
-			public static int channel_id = 2131099655;
+			// aapt resource value: 0x7F08000C
+			public static int action_bar_subtitle = 2131230732;
 			
-			// aapt resource value: 0x7F060008
-			public static int channel_information = 2131099656;
+			// aapt resource value: 0x7F08000D
+			public static int action_bar_title = 2131230733;
 			
-			// aapt resource value: 0x7F060009
-			public static int checkbox = 2131099657;
+			// aapt resource value: 0x7F08000E
+			public static int action_container = 2131230734;
 			
-			// aapt resource value: 0x7F06000A
-			public static int compatibility_mode = 2131099658;
+			// aapt resource value: 0x7F08000F
+			public static int action_context_bar = 2131230735;
 			
-			// aapt resource value: 0x7F06000B
-			public static int container = 2131099659;
+			// aapt resource value: 0x7F080010
+			public static int action_divider = 2131230736;
 			
-			// aapt resource value: 0x7F06000C
-			public static int content_holder = 2131099660;
+			// aapt resource value: 0x7F080011
+			public static int action_image = 2131230737;
 			
-			// aapt resource value: 0x7F06000D
-			public static int copy_button = 2131099661;
+			// aapt resource value: 0x7F080012
+			public static int action_menu_divider = 2131230738;
 			
-			// aapt resource value: 0x7F06000E
-			public static int date = 2131099662;
+			// aapt resource value: 0x7F080013
+			public static int action_menu_presenter = 2131230739;
 			
-			// aapt resource value: 0x7F06000F
-			public static int delete = 2131099663;
+			// aapt resource value: 0x7F080014
+			public static int action_mode_bar = 2131230740;
 			
-			// aapt resource value: 0x7F060010
-			public static int dismiss = 2131099664;
+			// aapt resource value: 0x7F080015
+			public static int action_mode_bar_stub = 2131230741;
 			
-			// aapt resource value: 0x7F060011
-			public static int error = 2131099665;
+			// aapt resource value: 0x7F080016
+			public static int action_mode_close_button = 2131230742;
 			
-			// aapt resource value: 0x7F060012
-			public static int error_message = 2131099666;
+			// aapt resource value: 0x7F080017
+			public static int action_text = 2131230743;
 			
-			// aapt resource value: 0x7F060013
-			public static int footer = 2131099667;
+			// aapt resource value: 0x7F080019
+			public static int activity_chooser_view_content = 2131230745;
 			
-			// aapt resource value: 0x7F060014
-			public static int footer_holder = 2131099668;
+			// aapt resource value: 0x7F08001A
+			public static int add = 2131230746;
 			
-			// aapt resource value: 0x7F060015
-			public static int heading = 2131099669;
+			// aapt resource value: 0x7F08001B
+			public static int alertTitle = 2131230747;
 			
-			// aapt resource value: 0x7F060016
-			public static int image = 2131099670;
+			// aapt resource value: 0x7F08001C
+			public static int all = 2131230748;
 			
-			// aapt resource value: 0x7F060017
-			public static int mark_read = 2131099671;
+			// aapt resource value: 0x7F080000
+			public static int ALT = 2131230720;
 			
-			// aapt resource value: 0x7F060018
-			public static int media = 2131099672;
+			// aapt resource value: 0x7F08001D
+			public static int always = 2131230749;
 			
-			// aapt resource value: 0x7F060019
-			public static int message_container = 2131099673;
+			// aapt resource value: 0x7F08001E
+			public static int async = 2131230750;
 			
-			// aapt resource value: 0x7F06001A
-			public static int message_list_container = 2131099674;
+			// aapt resource value: 0x7F08001F
+			public static int auto = 2131230751;
 			
-			// aapt resource value: 0x7F06001B
-			public static int modal = 2131099675;
+			// aapt resource value: 0x7F080020
+			public static int beginning = 2131230752;
 			
-			// aapt resource value: 0x7F06001C
-			public static int modal_content = 2131099676;
+			// aapt resource value: 0x7F080021
+			public static int blocking = 2131230753;
 			
-			// aapt resource value: 0x7F06001D
-			public static int never_allow = 2131099677;
+			// aapt resource value: 0x7F080022
+			public static int bottom = 2131230754;
 			
-			// aapt resource value: 0x7F06001E
-			public static int open_button = 2131099678;
+			// aapt resource value: 0x7F080023
+			public static int bottomtab_navarea = 2131230755;
 			
-			// aapt resource value: 0x7F06001F
-			public static int progress = 2131099679;
+			// aapt resource value: 0x7F080024
+			public static int bottomtab_tabbar = 2131230756;
 			
-			// aapt resource value: 0x7F060020
-			public static int retry_button = 2131099680;
+			// aapt resource value: 0x7F080025
+			public static int browser_actions_header_text = 2131230757;
 			
-			// aapt resource value: 0x7F060021
-			public static int select_all = 2131099681;
+			// aapt resource value: 0x7F080028
+			public static int browser_actions_menu_items = 2131230760;
 			
-			// aapt resource value: 0x7F060022
-			public static int share_button = 2131099682;
+			// aapt resource value: 0x7F080026
+			public static int browser_actions_menu_item_icon = 2131230758;
 			
-			// aapt resource value: 0x7F060023
-			public static int swipe_container = 2131099683;
+			// aapt resource value: 0x7F080027
+			public static int browser_actions_menu_item_text = 2131230759;
 			
-			// aapt resource value: 0x7F060024
-			public static int title = 2131099684;
+			// aapt resource value: 0x7F080029
+			public static int browser_actions_menu_view = 2131230761;
 			
-			// aapt resource value: 0x7F060025
-			public static int ua_iam_banner_content_left_image = 2131099685;
+			// aapt resource value: 0x7F08002A
+			public static int buttonPanel = 2131230762;
 			
-			// aapt resource value: 0x7F060026
-			public static int ua_iam_modal_header_body_media = 2131099686;
+			// aapt resource value: 0x7F08002B
+			public static int cancel_action = 2131230763;
 			
-			// aapt resource value: 0x7F060027
-			public static int web_view = 2131099687;
+			// aapt resource value: 0x7F08002C
+			public static int center = 2131230764;
+			
+			// aapt resource value: 0x7F08002D
+			public static int center_horizontal = 2131230765;
+			
+			// aapt resource value: 0x7F08002E
+			public static int center_vertical = 2131230766;
+			
+			// aapt resource value: 0x7F08002F
+			public static int checkbox = 2131230767;
+			
+			// aapt resource value: 0x7F080030
+			public static int chronometer = 2131230768;
+			
+			// aapt resource value: 0x7F080031
+			public static int clip_horizontal = 2131230769;
+			
+			// aapt resource value: 0x7F080032
+			public static int clip_vertical = 2131230770;
+			
+			// aapt resource value: 0x7F080033
+			public static int collapseActionView = 2131230771;
+			
+			// aapt resource value: 0x7F080034
+			public static int container = 2131230772;
+			
+			// aapt resource value: 0x7F080035
+			public static int content = 2131230773;
+			
+			// aapt resource value: 0x7F080036
+			public static int contentPanel = 2131230774;
+			
+			// aapt resource value: 0x7F080037
+			public static int coordinator = 2131230775;
+			
+			// aapt resource value: 0x7F080001
+			public static int CTRL = 2131230721;
+			
+			// aapt resource value: 0x7F080038
+			public static int custom = 2131230776;
+			
+			// aapt resource value: 0x7F080039
+			public static int customPanel = 2131230777;
+			
+			// aapt resource value: 0x7F08003A
+			public static int decor_content_parent = 2131230778;
+			
+			// aapt resource value: 0x7F08003B
+			public static int default_activity_button = 2131230779;
+			
+			// aapt resource value: 0x7F08003C
+			public static int design_bottom_sheet = 2131230780;
+			
+			// aapt resource value: 0x7F08003D
+			public static int design_menu_item_action_area = 2131230781;
+			
+			// aapt resource value: 0x7F08003E
+			public static int design_menu_item_action_area_stub = 2131230782;
+			
+			// aapt resource value: 0x7F08003F
+			public static int design_menu_item_text = 2131230783;
+			
+			// aapt resource value: 0x7F080040
+			public static int design_navigation_view = 2131230784;
+			
+			// aapt resource value: 0x7F080041
+			public static int disableHome = 2131230785;
+			
+			// aapt resource value: 0x7F080042
+			public static int edit_query = 2131230786;
+			
+			// aapt resource value: 0x7F080043
+			public static int end = 2131230787;
+			
+			// aapt resource value: 0x7F080044
+			public static int end_padder = 2131230788;
+			
+			// aapt resource value: 0x7F080045
+			public static int enterAlways = 2131230789;
+			
+			// aapt resource value: 0x7F080046
+			public static int enterAlwaysCollapsed = 2131230790;
+			
+			// aapt resource value: 0x7F080047
+			public static int exitUntilCollapsed = 2131230791;
+			
+			// aapt resource value: 0x7F080049
+			public static int expanded_menu = 2131230793;
+			
+			// aapt resource value: 0x7F080048
+			public static int expand_activities_button = 2131230792;
+			
+			// aapt resource value: 0x7F08004A
+			public static int fill = 2131230794;
+			
+			// aapt resource value: 0x7F08004D
+			public static int filled = 2131230797;
+			
+			// aapt resource value: 0x7F08004B
+			public static int fill_horizontal = 2131230795;
+			
+			// aapt resource value: 0x7F08004C
+			public static int fill_vertical = 2131230796;
+			
+			// aapt resource value: 0x7F08004E
+			public static int @fixed = 2131230798;
+			
+			// aapt resource value: 0x7F08004F
+			public static int flyoutcontent_appbar = 2131230799;
+			
+			// aapt resource value: 0x7F080050
+			public static int flyoutcontent_recycler = 2131230800;
+			
+			// aapt resource value: 0x7F080051
+			public static int forever = 2131230801;
+			
+			// aapt resource value: 0x7F080002
+			public static int FUNCTION = 2131230722;
+			
+			// aapt resource value: 0x7F080052
+			public static int ghost_view = 2131230802;
+			
+			// aapt resource value: 0x7F080053
+			public static int group_divider = 2131230803;
+			
+			// aapt resource value: 0x7F080054
+			public static int home = 2131230804;
+			
+			// aapt resource value: 0x7F080055
+			public static int homeAsUp = 2131230805;
+			
+			// aapt resource value: 0x7F080056
+			public static int icon = 2131230806;
+			
+			// aapt resource value: 0x7F080057
+			public static int icon_group = 2131230807;
+			
+			// aapt resource value: 0x7F080058
+			public static int ifRoom = 2131230808;
+			
+			// aapt resource value: 0x7F080059
+			public static int image = 2131230809;
+			
+			// aapt resource value: 0x7F08005A
+			public static int info = 2131230810;
+			
+			// aapt resource value: 0x7F08005B
+			public static int italic = 2131230811;
+			
+			// aapt resource value: 0x7F08005C
+			public static int item_touch_helper_previous_elevation = 2131230812;
+			
+			// aapt resource value: 0x7F08005D
+			public static int labeled = 2131230813;
+			
+			// aapt resource value: 0x7F08005E
+			public static int largeLabel = 2131230814;
+			
+			// aapt resource value: 0x7F08005F
+			public static int left = 2131230815;
+			
+			// aapt resource value: 0x7F080060
+			public static int line1 = 2131230816;
+			
+			// aapt resource value: 0x7F080061
+			public static int line3 = 2131230817;
+			
+			// aapt resource value: 0x7F080062
+			public static int listMode = 2131230818;
+			
+			// aapt resource value: 0x7F080063
+			public static int list_item = 2131230819;
+			
+			// aapt resource value: 0x7F080064
+			public static int main_appbar = 2131230820;
+			
+			// aapt resource value: 0x7F080065
+			public static int main_tablayout = 2131230821;
+			
+			// aapt resource value: 0x7F080066
+			public static int main_toolbar = 2131230822;
+			
+			// aapt resource value: 0x7F080067
+			public static int main_viewpager = 2131230823;
+			
+			// aapt resource value: 0x7F080068
+			public static int masked = 2131230824;
+			
+			// aapt resource value: 0x7F080069
+			public static int media_actions = 2131230825;
+			
+			// aapt resource value: 0x7F08006A
+			public static int message = 2131230826;
+			
+			// aapt resource value: 0x7F080003
+			public static int META = 2131230723;
+			
+			// aapt resource value: 0x7F08006B
+			public static int middle = 2131230827;
+			
+			// aapt resource value: 0x7F08006C
+			public static int mini = 2131230828;
+			
+			// aapt resource value: 0x7F08006D
+			public static int mtrl_child_content_container = 2131230829;
+			
+			// aapt resource value: 0x7F08006E
+			public static int mtrl_internal_children_alpha_tag = 2131230830;
+			
+			// aapt resource value: 0x7F08006F
+			public static int multiply = 2131230831;
+			
+			// aapt resource value: 0x7F080070
+			public static int navigation_header_container = 2131230832;
+			
+			// aapt resource value: 0x7F080071
+			public static int never = 2131230833;
+			
+			// aapt resource value: 0x7F080072
+			public static int none = 2131230834;
+			
+			// aapt resource value: 0x7F080073
+			public static int normal = 2131230835;
+			
+			// aapt resource value: 0x7F080074
+			public static int notification_background = 2131230836;
+			
+			// aapt resource value: 0x7F080075
+			public static int notification_main_column = 2131230837;
+			
+			// aapt resource value: 0x7F080076
+			public static int notification_main_column_container = 2131230838;
+			
+			// aapt resource value: 0x7F080077
+			public static int outline = 2131230839;
+			
+			// aapt resource value: 0x7F080078
+			public static int parallax = 2131230840;
+			
+			// aapt resource value: 0x7F080079
+			public static int parentPanel = 2131230841;
+			
+			// aapt resource value: 0x7F08007A
+			public static int parent_matrix = 2131230842;
+			
+			// aapt resource value: 0x7F08007B
+			public static int pin = 2131230843;
+			
+			// aapt resource value: 0x7F08007C
+			public static int progress_circular = 2131230844;
+			
+			// aapt resource value: 0x7F08007D
+			public static int progress_horizontal = 2131230845;
+			
+			// aapt resource value: 0x7F08007E
+			public static int radio = 2131230846;
+			
+			// aapt resource value: 0x7F08007F
+			public static int right = 2131230847;
+			
+			// aapt resource value: 0x7F080080
+			public static int right_icon = 2131230848;
+			
+			// aapt resource value: 0x7F080081
+			public static int right_side = 2131230849;
+			
+			// aapt resource value: 0x7F080082
+			public static int save_image_matrix = 2131230850;
+			
+			// aapt resource value: 0x7F080083
+			public static int save_non_transition_alpha = 2131230851;
+			
+			// aapt resource value: 0x7F080084
+			public static int save_scale_type = 2131230852;
+			
+			// aapt resource value: 0x7F080085
+			public static int screen = 2131230853;
+			
+			// aapt resource value: 0x7F080086
+			public static int scroll = 2131230854;
+			
+			// aapt resource value: 0x7F08008A
+			public static int scrollable = 2131230858;
+			
+			// aapt resource value: 0x7F080087
+			public static int scrollIndicatorDown = 2131230855;
+			
+			// aapt resource value: 0x7F080088
+			public static int scrollIndicatorUp = 2131230856;
+			
+			// aapt resource value: 0x7F080089
+			public static int scrollView = 2131230857;
+			
+			// aapt resource value: 0x7F08008B
+			public static int search_badge = 2131230859;
+			
+			// aapt resource value: 0x7F08008C
+			public static int search_bar = 2131230860;
+			
+			// aapt resource value: 0x7F08008D
+			public static int search_button = 2131230861;
+			
+			// aapt resource value: 0x7F08008E
+			public static int search_close_btn = 2131230862;
+			
+			// aapt resource value: 0x7F08008F
+			public static int search_edit_frame = 2131230863;
+			
+			// aapt resource value: 0x7F080090
+			public static int search_go_btn = 2131230864;
+			
+			// aapt resource value: 0x7F080091
+			public static int search_mag_icon = 2131230865;
+			
+			// aapt resource value: 0x7F080092
+			public static int search_plate = 2131230866;
+			
+			// aapt resource value: 0x7F080093
+			public static int search_src_text = 2131230867;
+			
+			// aapt resource value: 0x7F080094
+			public static int search_voice_btn = 2131230868;
+			
+			// aapt resource value: 0x7F080096
+			public static int selected = 2131230870;
+			
+			// aapt resource value: 0x7F080095
+			public static int select_dialog_listview = 2131230869;
+			
+			// aapt resource value: 0x7F080097
+			public static int shellcontent_appbar = 2131230871;
+			
+			// aapt resource value: 0x7F080098
+			public static int shellcontent_toolbar = 2131230872;
+			
+			// aapt resource value: 0x7F080004
+			public static int SHIFT = 2131230724;
+			
+			// aapt resource value: 0x7F080099
+			public static int shortcut = 2131230873;
+			
+			// aapt resource value: 0x7F08009A
+			public static int showCustom = 2131230874;
+			
+			// aapt resource value: 0x7F08009B
+			public static int showHome = 2131230875;
+			
+			// aapt resource value: 0x7F08009C
+			public static int showTitle = 2131230876;
+			
+			// aapt resource value: 0x7F08009D
+			public static int smallLabel = 2131230877;
+			
+			// aapt resource value: 0x7F08009E
+			public static int snackbar_action = 2131230878;
+			
+			// aapt resource value: 0x7F08009F
+			public static int snackbar_text = 2131230879;
+			
+			// aapt resource value: 0x7F0800A0
+			public static int snap = 2131230880;
+			
+			// aapt resource value: 0x7F0800A1
+			public static int snapMargins = 2131230881;
+			
+			// aapt resource value: 0x7F0800A2
+			public static int spacer = 2131230882;
+			
+			// aapt resource value: 0x7F0800A3
+			public static int split_action_bar = 2131230883;
+			
+			// aapt resource value: 0x7F0800A4
+			public static int src_atop = 2131230884;
+			
+			// aapt resource value: 0x7F0800A5
+			public static int src_in = 2131230885;
+			
+			// aapt resource value: 0x7F0800A6
+			public static int src_over = 2131230886;
+			
+			// aapt resource value: 0x7F0800A7
+			public static int start = 2131230887;
+			
+			// aapt resource value: 0x7F0800A8
+			public static int status_bar_latest_event_content = 2131230888;
+			
+			// aapt resource value: 0x7F0800A9
+			public static int stretch = 2131230889;
+			
+			// aapt resource value: 0x7F0800AA
+			public static int submenuarrow = 2131230890;
+			
+			// aapt resource value: 0x7F0800AB
+			public static int submit_area = 2131230891;
+			
+			// aapt resource value: 0x7F080005
+			public static int SYM = 2131230725;
+			
+			// aapt resource value: 0x7F0800AC
+			public static int tabMode = 2131230892;
+			
+			// aapt resource value: 0x7F0800AD
+			public static int tag_transition_group = 2131230893;
+			
+			// aapt resource value: 0x7F0800AE
+			public static int tag_unhandled_key_event_manager = 2131230894;
+			
+			// aapt resource value: 0x7F0800AF
+			public static int tag_unhandled_key_listeners = 2131230895;
+			
+			// aapt resource value: 0x7F0800B0
+			public static int text = 2131230896;
+			
+			// aapt resource value: 0x7F0800B1
+			public static int text2 = 2131230897;
+			
+			// aapt resource value: 0x7F0800B6
+			public static int textinput_counter = 2131230902;
+			
+			// aapt resource value: 0x7F0800B7
+			public static int textinput_error = 2131230903;
+			
+			// aapt resource value: 0x7F0800B8
+			public static int textinput_helper_text = 2131230904;
+			
+			// aapt resource value: 0x7F0800B2
+			public static int textSpacerNoButtons = 2131230898;
+			
+			// aapt resource value: 0x7F0800B3
+			public static int textSpacerNoTitle = 2131230899;
+			
+			// aapt resource value: 0x7F0800B4
+			public static int textStart = 2131230900;
+			
+			// aapt resource value: 0x7F0800B5
+			public static int text_input_password_toggle = 2131230901;
+			
+			// aapt resource value: 0x7F0800B9
+			public static int time = 2131230905;
+			
+			// aapt resource value: 0x7F0800BA
+			public static int title = 2131230906;
+			
+			// aapt resource value: 0x7F0800BB
+			public static int titleDividerNoCustom = 2131230907;
+			
+			// aapt resource value: 0x7F0800BC
+			public static int title_template = 2131230908;
+			
+			// aapt resource value: 0x7F0800BD
+			public static int top = 2131230909;
+			
+			// aapt resource value: 0x7F0800BE
+			public static int topPanel = 2131230910;
+			
+			// aapt resource value: 0x7F0800BF
+			public static int touch_outside = 2131230911;
+			
+			// aapt resource value: 0x7F0800C0
+			public static int transition_current_scene = 2131230912;
+			
+			// aapt resource value: 0x7F0800C1
+			public static int transition_layout_save = 2131230913;
+			
+			// aapt resource value: 0x7F0800C2
+			public static int transition_position = 2131230914;
+			
+			// aapt resource value: 0x7F0800C3
+			public static int transition_scene_layoutid_cache = 2131230915;
+			
+			// aapt resource value: 0x7F0800C4
+			public static int transition_transform = 2131230916;
+			
+			// aapt resource value: 0x7F0800C5
+			public static int uniform = 2131230917;
+			
+			// aapt resource value: 0x7F0800C6
+			public static int unlabeled = 2131230918;
+			
+			// aapt resource value: 0x7F0800C7
+			public static int up = 2131230919;
+			
+			// aapt resource value: 0x7F0800C8
+			public static int useLogo = 2131230920;
+			
+			// aapt resource value: 0x7F0800C9
+			public static int view_offset_helper = 2131230921;
+			
+			// aapt resource value: 0x7F0800CA
+			public static int visible = 2131230922;
+			
+			// aapt resource value: 0x7F0800CB
+			public static int withText = 2131230923;
+			
+			// aapt resource value: 0x7F0800CC
+			public static int wrap_content = 2131230924;
 			
 			static Id()
 			{
@@ -387,8 +3674,50 @@ namespace AirshipBindings.NETStandard
 		public partial class Integer
 		{
 			
-			// aapt resource value: 0x7F070000
-			public static int ua_iam_banner_animation_duration = 2131165184;
+			// aapt resource value: 0x7F090000
+			public static int abc_config_activityDefaultDur = 2131296256;
+			
+			// aapt resource value: 0x7F090001
+			public static int abc_config_activityShortDur = 2131296257;
+			
+			// aapt resource value: 0x7F090002
+			public static int app_bar_elevation_anim_duration = 2131296258;
+			
+			// aapt resource value: 0x7F090003
+			public static int bottom_sheet_slide_duration = 2131296259;
+			
+			// aapt resource value: 0x7F090004
+			public static int cancel_button_image_alpha = 2131296260;
+			
+			// aapt resource value: 0x7F090005
+			public static int config_tooltipAnimTime = 2131296261;
+			
+			// aapt resource value: 0x7F090006
+			public static int design_snackbar_text_max_lines = 2131296262;
+			
+			// aapt resource value: 0x7F090007
+			public static int design_tab_indicator_anim_duration_ms = 2131296263;
+			
+			// aapt resource value: 0x7F090008
+			public static int hide_password_duration = 2131296264;
+			
+			// aapt resource value: 0x7F090009
+			public static int mtrl_btn_anim_delay_ms = 2131296265;
+			
+			// aapt resource value: 0x7F09000A
+			public static int mtrl_btn_anim_duration_ms = 2131296266;
+			
+			// aapt resource value: 0x7F09000B
+			public static int mtrl_chip_anim_duration = 2131296267;
+			
+			// aapt resource value: 0x7F09000C
+			public static int mtrl_tab_indicator_anim_duration_ms = 2131296268;
+			
+			// aapt resource value: 0x7F09000D
+			public static int show_password_duration = 2131296269;
+			
+			// aapt resource value: 0x7F09000E
+			public static int status_bar_notification_info_maxnum = 2131296270;
 			
 			static Integer()
 			{
@@ -400,83 +3729,240 @@ namespace AirshipBindings.NETStandard
 			}
 		}
 		
+		public partial class Interpolator
+		{
+			
+			// aapt resource value: 0x7F0A0000
+			public static int mtrl_fast_out_linear_in = 2131361792;
+			
+			// aapt resource value: 0x7F0A0001
+			public static int mtrl_fast_out_slow_in = 2131361793;
+			
+			// aapt resource value: 0x7F0A0002
+			public static int mtrl_linear = 2131361794;
+			
+			// aapt resource value: 0x7F0A0003
+			public static int mtrl_linear_out_slow_in = 2131361795;
+			
+			static Interpolator()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Interpolator()
+			{
+			}
+		}
+		
 		public partial class Layout
 		{
 			
-			// aapt resource value: 0x7F080000
-			public static int ua_activity_channel_capture = 2131230720;
+			// aapt resource value: 0x7F0B0000
+			public static int abc_action_bar_title_item = 2131427328;
 			
-			// aapt resource value: 0x7F080001
-			public static int ua_fragment_mc = 2131230721;
+			// aapt resource value: 0x7F0B0001
+			public static int abc_action_bar_up_container = 2131427329;
 			
-			// aapt resource value: 0x7F080002
-			public static int ua_fragment_message = 2131230722;
+			// aapt resource value: 0x7F0B0002
+			public static int abc_action_menu_item_layout = 2131427330;
 			
-			// aapt resource value: 0x7F080003
-			public static int ua_fragment_message_list = 2131230723;
+			// aapt resource value: 0x7F0B0003
+			public static int abc_action_menu_layout = 2131427331;
 			
-			// aapt resource value: 0x7F080004
-			public static int ua_fragment_no_message_selected = 2131230724;
+			// aapt resource value: 0x7F0B0004
+			public static int abc_action_mode_bar = 2131427332;
 			
-			// aapt resource value: 0x7F080005
-			public static int ua_iam_banner_bottom = 2131230725;
+			// aapt resource value: 0x7F0B0005
+			public static int abc_action_mode_close_item_material = 2131427333;
 			
-			// aapt resource value: 0x7F080006
-			public static int ua_iam_banner_button = 2131230726;
+			// aapt resource value: 0x7F0B0006
+			public static int abc_activity_chooser_view = 2131427334;
 			
-			// aapt resource value: 0x7F080007
-			public static int ua_iam_banner_content_left_media = 2131230727;
+			// aapt resource value: 0x7F0B0007
+			public static int abc_activity_chooser_view_list_item = 2131427335;
 			
-			// aapt resource value: 0x7F080008
-			public static int ua_iam_banner_content_right_media = 2131230728;
+			// aapt resource value: 0x7F0B0008
+			public static int abc_alert_dialog_button_bar_material = 2131427336;
 			
-			// aapt resource value: 0x7F080009
-			public static int ua_iam_banner_top = 2131230729;
+			// aapt resource value: 0x7F0B0009
+			public static int abc_alert_dialog_material = 2131427337;
 			
-			// aapt resource value: 0x7F08000A
-			public static int ua_iam_fullscreen_button = 2131230730;
+			// aapt resource value: 0x7F0B000A
+			public static int abc_alert_dialog_title_material = 2131427338;
 			
-			// aapt resource value: 0x7F08000B
-			public static int ua_iam_fullscreen_header_body_media = 2131230731;
+			// aapt resource value: 0x7F0B000B
+			public static int abc_cascading_menu_item_layout = 2131427339;
 			
-			// aapt resource value: 0x7F08000C
-			public static int ua_iam_fullscreen_header_media_body = 2131230732;
+			// aapt resource value: 0x7F0B000C
+			public static int abc_dialog_title_material = 2131427340;
 			
-			// aapt resource value: 0x7F08000D
-			public static int ua_iam_fullscreen_media_header_body = 2131230733;
+			// aapt resource value: 0x7F0B000D
+			public static int abc_expanded_menu_layout = 2131427341;
 			
-			// aapt resource value: 0x7F08000E
-			public static int ua_iam_html = 2131230734;
+			// aapt resource value: 0x7F0B000E
+			public static int abc_list_menu_item_checkbox = 2131427342;
 			
-			// aapt resource value: 0x7F08000F
-			public static int ua_iam_html_fullscreen = 2131230735;
+			// aapt resource value: 0x7F0B000F
+			public static int abc_list_menu_item_icon = 2131427343;
 			
-			// aapt resource value: 0x7F080010
-			public static int ua_iam_modal = 2131230736;
+			// aapt resource value: 0x7F0B0010
+			public static int abc_list_menu_item_layout = 2131427344;
 			
-			// aapt resource value: 0x7F080011
-			public static int ua_iam_modal_button = 2131230737;
+			// aapt resource value: 0x7F0B0011
+			public static int abc_list_menu_item_radio = 2131427345;
 			
-			// aapt resource value: 0x7F080012
-			public static int ua_iam_modal_fullscreen = 2131230738;
+			// aapt resource value: 0x7F0B0012
+			public static int abc_popup_menu_header_item_layout = 2131427346;
 			
-			// aapt resource value: 0x7F080013
-			public static int ua_iam_modal_header_body_media = 2131230739;
+			// aapt resource value: 0x7F0B0013
+			public static int abc_popup_menu_item_layout = 2131427347;
 			
-			// aapt resource value: 0x7F080014
-			public static int ua_iam_modal_header_media_body = 2131230740;
+			// aapt resource value: 0x7F0B0014
+			public static int abc_screen_content_include = 2131427348;
 			
-			// aapt resource value: 0x7F080015
-			public static int ua_iam_modal_media_header_body = 2131230741;
+			// aapt resource value: 0x7F0B0015
+			public static int abc_screen_simple = 2131427349;
 			
-			// aapt resource value: 0x7F080016
-			public static int ua_item_mc = 2131230742;
+			// aapt resource value: 0x7F0B0016
+			public static int abc_screen_simple_overlay_action_mode = 2131427350;
 			
-			// aapt resource value: 0x7F080017
-			public static int ua_item_mc_content = 2131230743;
+			// aapt resource value: 0x7F0B0017
+			public static int abc_screen_toolbar = 2131427351;
 			
-			// aapt resource value: 0x7F080018
-			public static int ua_item_mc_icon_content = 2131230744;
+			// aapt resource value: 0x7F0B0018
+			public static int abc_search_dropdown_item_icons_2line = 2131427352;
+			
+			// aapt resource value: 0x7F0B0019
+			public static int abc_search_view = 2131427353;
+			
+			// aapt resource value: 0x7F0B001A
+			public static int abc_select_dialog_material = 2131427354;
+			
+			// aapt resource value: 0x7F0B001B
+			public static int abc_tooltip = 2131427355;
+			
+			// aapt resource value: 0x7F0B001C
+			public static int BottomTabLayout = 2131427356;
+			
+			// aapt resource value: 0x7F0B001D
+			public static int browser_actions_context_menu_page = 2131427357;
+			
+			// aapt resource value: 0x7F0B001E
+			public static int browser_actions_context_menu_row = 2131427358;
+			
+			// aapt resource value: 0x7F0B001F
+			public static int design_bottom_navigation_item = 2131427359;
+			
+			// aapt resource value: 0x7F0B0020
+			public static int design_bottom_sheet_dialog = 2131427360;
+			
+			// aapt resource value: 0x7F0B0021
+			public static int design_layout_snackbar = 2131427361;
+			
+			// aapt resource value: 0x7F0B0022
+			public static int design_layout_snackbar_include = 2131427362;
+			
+			// aapt resource value: 0x7F0B0023
+			public static int design_layout_tab_icon = 2131427363;
+			
+			// aapt resource value: 0x7F0B0024
+			public static int design_layout_tab_text = 2131427364;
+			
+			// aapt resource value: 0x7F0B0025
+			public static int design_menu_item_action_area = 2131427365;
+			
+			// aapt resource value: 0x7F0B0026
+			public static int design_navigation_item = 2131427366;
+			
+			// aapt resource value: 0x7F0B0027
+			public static int design_navigation_item_header = 2131427367;
+			
+			// aapt resource value: 0x7F0B0028
+			public static int design_navigation_item_separator = 2131427368;
+			
+			// aapt resource value: 0x7F0B0029
+			public static int design_navigation_item_subheader = 2131427369;
+			
+			// aapt resource value: 0x7F0B002A
+			public static int design_navigation_menu = 2131427370;
+			
+			// aapt resource value: 0x7F0B002B
+			public static int design_navigation_menu_item = 2131427371;
+			
+			// aapt resource value: 0x7F0B002C
+			public static int design_text_input_password_icon = 2131427372;
+			
+			// aapt resource value: 0x7F0B002D
+			public static int FlyoutContent = 2131427373;
+			
+			// aapt resource value: 0x7F0B002E
+			public static int mtrl_layout_snackbar = 2131427374;
+			
+			// aapt resource value: 0x7F0B002F
+			public static int mtrl_layout_snackbar_include = 2131427375;
+			
+			// aapt resource value: 0x7F0B0030
+			public static int notification_action = 2131427376;
+			
+			// aapt resource value: 0x7F0B0031
+			public static int notification_action_tombstone = 2131427377;
+			
+			// aapt resource value: 0x7F0B0032
+			public static int notification_media_action = 2131427378;
+			
+			// aapt resource value: 0x7F0B0033
+			public static int notification_media_cancel_action = 2131427379;
+			
+			// aapt resource value: 0x7F0B0034
+			public static int notification_template_big_media = 2131427380;
+			
+			// aapt resource value: 0x7F0B0035
+			public static int notification_template_big_media_custom = 2131427381;
+			
+			// aapt resource value: 0x7F0B0036
+			public static int notification_template_big_media_narrow = 2131427382;
+			
+			// aapt resource value: 0x7F0B0037
+			public static int notification_template_big_media_narrow_custom = 2131427383;
+			
+			// aapt resource value: 0x7F0B0038
+			public static int notification_template_custom_big = 2131427384;
+			
+			// aapt resource value: 0x7F0B0039
+			public static int notification_template_icon_group = 2131427385;
+			
+			// aapt resource value: 0x7F0B003A
+			public static int notification_template_lines_media = 2131427386;
+			
+			// aapt resource value: 0x7F0B003B
+			public static int notification_template_media = 2131427387;
+			
+			// aapt resource value: 0x7F0B003C
+			public static int notification_template_media_custom = 2131427388;
+			
+			// aapt resource value: 0x7F0B003D
+			public static int notification_template_part_chronometer = 2131427389;
+			
+			// aapt resource value: 0x7F0B003E
+			public static int notification_template_part_time = 2131427390;
+			
+			// aapt resource value: 0x7F0B003F
+			public static int RootLayout = 2131427391;
+			
+			// aapt resource value: 0x7F0B0040
+			public static int select_dialog_item_material = 2131427392;
+			
+			// aapt resource value: 0x7F0B0041
+			public static int select_dialog_multichoice_material = 2131427393;
+			
+			// aapt resource value: 0x7F0B0042
+			public static int select_dialog_singlechoice_material = 2131427394;
+			
+			// aapt resource value: 0x7F0B0043
+			public static int ShellContent = 2131427395;
+			
+			// aapt resource value: 0x7F0B0044
+			public static int support_simple_spinner_dropdown_item = 2131427396;
 			
 			static Layout()
 			{
@@ -488,278 +3974,173 @@ namespace AirshipBindings.NETStandard
 			}
 		}
 		
-		public partial class Menu
-		{
-			
-			// aapt resource value: 0x7F090000
-			public static int ua_mc_action_mode = 2131296256;
-			
-			static Menu()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Menu()
-			{
-			}
-		}
-		
-		public partial class Raw
-		{
-			
-			// aapt resource value: 0x7F0B0000
-			public static int ua_blank_favicon = 2131427328;
-			
-			// aapt resource value: 0x7F0B0001
-			public static int ua_native_bridge = 2131427329;
-			
-			static Raw()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Raw()
-			{
-			}
-		}
-		
-		public partial class Plurals
-		{
-			
-			// aapt resource value: 0x7F0A0000
-			public static int ua_selected_count = 2131361792;
-			
-			static Plurals()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Plurals()
-			{
-			}
-		}
-		
 		public partial class String
 		{
 			
 			// aapt resource value: 0x7F0C0000
-			public static int library_name = 2131492864;
+			public static int abc_action_bar_home_description = 2131492864;
 			
 			// aapt resource value: 0x7F0C0001
-			public static int ua_cancel = 2131492865;
+			public static int abc_action_bar_up_description = 2131492865;
 			
 			// aapt resource value: 0x7F0C0002
-			public static int ua_channel_copy_toast = 2131492866;
+			public static int abc_action_menu_overflow_description = 2131492866;
 			
 			// aapt resource value: 0x7F0C0003
-			public static int ua_channel_id = 2131492867;
-			
-			// aapt resource value: 0x7F0C0004
-			public static int ua_channel_notification_ticker = 2131492868;
+			public static int abc_action_mode_done = 2131492867;
 			
 			// aapt resource value: 0x7F0C0005
-			public static int ua_connection_error = 2131492869;
+			public static int abc_activitychooserview_choose_application = 2131492869;
+			
+			// aapt resource value: 0x7F0C0004
+			public static int abc_activity_chooser_view_see_all = 2131492868;
 			
 			// aapt resource value: 0x7F0C0006
-			public static int ua_content_error = 2131492870;
+			public static int abc_capital_off = 2131492870;
 			
 			// aapt resource value: 0x7F0C0007
-			public static int ua_default_channel_description = 2131492871;
+			public static int abc_capital_on = 2131492871;
 			
 			// aapt resource value: 0x7F0C0008
-			public static int ua_default_channel_name = 2131492872;
+			public static int abc_font_family_body_1_material = 2131492872;
 			
 			// aapt resource value: 0x7F0C0009
-			public static int ua_delete = 2131492873;
+			public static int abc_font_family_body_2_material = 2131492873;
 			
 			// aapt resource value: 0x7F0C000A
-			public static int ua_emoji_happy = 2131492874;
+			public static int abc_font_family_button_material = 2131492874;
 			
 			// aapt resource value: 0x7F0C000B
-			public static int ua_emoji_sad = 2131492875;
+			public static int abc_font_family_caption_material = 2131492875;
 			
 			// aapt resource value: 0x7F0C000C
-			public static int ua_emoji_thumbs_down = 2131492876;
+			public static int abc_font_family_display_1_material = 2131492876;
 			
 			// aapt resource value: 0x7F0C000D
-			public static int ua_emoji_thumbs_up = 2131492877;
+			public static int abc_font_family_display_2_material = 2131492877;
 			
 			// aapt resource value: 0x7F0C000E
-			public static int ua_empty_message_list = 2131492878;
+			public static int abc_font_family_display_3_material = 2131492878;
 			
 			// aapt resource value: 0x7F0C000F
-			public static int ua_low_priority_channel_description = 2131492879;
+			public static int abc_font_family_display_4_material = 2131492879;
 			
 			// aapt resource value: 0x7F0C0010
-			public static int ua_low_priority_channel_id = 2131492880;
+			public static int abc_font_family_headline_material = 2131492880;
 			
 			// aapt resource value: 0x7F0C0011
-			public static int ua_low_priority_channel_name = 2131492881;
+			public static int abc_font_family_menu_material = 2131492881;
 			
 			// aapt resource value: 0x7F0C0012
-			public static int ua_mark_read = 2131492882;
+			public static int abc_font_family_subhead_material = 2131492882;
 			
 			// aapt resource value: 0x7F0C0013
-			public static int ua_mc_failed_to_load = 2131492883;
+			public static int abc_font_family_title_material = 2131492883;
 			
 			// aapt resource value: 0x7F0C0014
-			public static int ua_mc_no_longer_available = 2131492884;
+			public static int abc_menu_alt_shortcut_label = 2131492884;
 			
 			// aapt resource value: 0x7F0C0015
-			public static int ua_message_center_title = 2131492885;
+			public static int abc_menu_ctrl_shortcut_label = 2131492885;
 			
 			// aapt resource value: 0x7F0C0016
-			public static int ua_message_not_selected = 2131492886;
+			public static int abc_menu_delete_shortcut_label = 2131492886;
 			
 			// aapt resource value: 0x7F0C0017
-			public static int ua_min_priority_channel_description = 2131492887;
+			public static int abc_menu_enter_shortcut_label = 2131492887;
 			
 			// aapt resource value: 0x7F0C0018
-			public static int ua_min_priority_channel_id = 2131492888;
+			public static int abc_menu_function_shortcut_label = 2131492888;
 			
 			// aapt resource value: 0x7F0C0019
-			public static int ua_min_priority_channel_name = 2131492889;
+			public static int abc_menu_meta_shortcut_label = 2131492889;
 			
 			// aapt resource value: 0x7F0C001A
-			public static int ua_news_channel_description = 2131492890;
+			public static int abc_menu_shift_shortcut_label = 2131492890;
 			
 			// aapt resource value: 0x7F0C001B
-			public static int ua_news_channel_id = 2131492891;
+			public static int abc_menu_space_shortcut_label = 2131492891;
 			
 			// aapt resource value: 0x7F0C001C
-			public static int ua_news_channel_name = 2131492892;
+			public static int abc_menu_sym_shortcut_label = 2131492892;
 			
 			// aapt resource value: 0x7F0C001D
-			public static int ua_notification_button_accept = 2131492893;
-			
-			// aapt resource value: 0x7F0C001E
-			public static int ua_notification_button_add = 2131492894;
+			public static int abc_prepend_shortcut_label = 2131492893;
 			
 			// aapt resource value: 0x7F0C001F
-			public static int ua_notification_button_add_to_calendar = 2131492895;
+			public static int abc_searchview_description_clear = 2131492895;
 			
 			// aapt resource value: 0x7F0C0020
-			public static int ua_notification_button_book_now = 2131492896;
+			public static int abc_searchview_description_query = 2131492896;
 			
 			// aapt resource value: 0x7F0C0021
-			public static int ua_notification_button_buy_now = 2131492897;
+			public static int abc_searchview_description_search = 2131492897;
 			
 			// aapt resource value: 0x7F0C0022
-			public static int ua_notification_button_copy = 2131492898;
+			public static int abc_searchview_description_submit = 2131492898;
 			
 			// aapt resource value: 0x7F0C0023
-			public static int ua_notification_button_decline = 2131492899;
+			public static int abc_searchview_description_voice = 2131492899;
+			
+			// aapt resource value: 0x7F0C001E
+			public static int abc_search_hint = 2131492894;
 			
 			// aapt resource value: 0x7F0C0024
-			public static int ua_notification_button_dislike = 2131492900;
+			public static int abc_shareactionprovider_share_with = 2131492900;
 			
 			// aapt resource value: 0x7F0C0025
-			public static int ua_notification_button_download = 2131492901;
+			public static int abc_shareactionprovider_share_with_application = 2131492901;
 			
 			// aapt resource value: 0x7F0C0026
-			public static int ua_notification_button_follow = 2131492902;
+			public static int abc_toolbar_collapse_description = 2131492902;
 			
 			// aapt resource value: 0x7F0C0027
-			public static int ua_notification_button_less_like = 2131492903;
+			public static int appbar_scrolling_view_behavior = 2131492903;
 			
 			// aapt resource value: 0x7F0C0028
-			public static int ua_notification_button_like = 2131492904;
+			public static int bottom_sheet_behavior = 2131492904;
 			
 			// aapt resource value: 0x7F0C0029
-			public static int ua_notification_button_more_like = 2131492905;
+			public static int character_counter_content_description = 2131492905;
 			
 			// aapt resource value: 0x7F0C002A
-			public static int ua_notification_button_no = 2131492906;
+			public static int character_counter_pattern = 2131492906;
 			
 			// aapt resource value: 0x7F0C002B
-			public static int ua_notification_button_opt_in = 2131492907;
+			public static int fab_transformation_scrim_behavior = 2131492907;
 			
 			// aapt resource value: 0x7F0C002C
-			public static int ua_notification_button_opt_out = 2131492908;
+			public static int fab_transformation_sheet_behavior = 2131492908;
 			
 			// aapt resource value: 0x7F0C002D
-			public static int ua_notification_button_rate_now = 2131492909;
+			public static int hide_bottom_view_on_scroll_behavior = 2131492909;
 			
 			// aapt resource value: 0x7F0C002E
-			public static int ua_notification_button_remind = 2131492910;
+			public static int library_name = 2131492910;
 			
 			// aapt resource value: 0x7F0C002F
-			public static int ua_notification_button_save = 2131492911;
+			public static int mtrl_chip_close_icon_content_description = 2131492911;
 			
 			// aapt resource value: 0x7F0C0030
-			public static int ua_notification_button_search = 2131492912;
+			public static int password_toggle_content_description = 2131492912;
 			
 			// aapt resource value: 0x7F0C0031
-			public static int ua_notification_button_send_info = 2131492913;
+			public static int path_password_eye = 2131492913;
 			
 			// aapt resource value: 0x7F0C0032
-			public static int ua_notification_button_share = 2131492914;
+			public static int path_password_eye_mask_strike_through = 2131492914;
 			
 			// aapt resource value: 0x7F0C0033
-			public static int ua_notification_button_shop_now = 2131492915;
+			public static int path_password_eye_mask_visible = 2131492915;
 			
 			// aapt resource value: 0x7F0C0034
-			public static int ua_notification_button_tell_me_more = 2131492916;
+			public static int path_password_strike_through = 2131492916;
 			
 			// aapt resource value: 0x7F0C0035
-			public static int ua_notification_button_unfollow = 2131492917;
+			public static int search_menu_title = 2131492917;
 			
 			// aapt resource value: 0x7F0C0036
-			public static int ua_notification_button_yes = 2131492918;
-			
-			// aapt resource value: 0x7F0C0037
-			public static int ua_ok = 2131492919;
-			
-			// aapt resource value: 0x7F0C0038
-			public static int ua_open = 2131492920;
-			
-			// aapt resource value: 0x7F0C0039
-			public static int ua_rate_app_action_default_body = 2131492921;
-			
-			// aapt resource value: 0x7F0C003A
-			public static int ua_rate_app_action_default_rate_negative_button = 2131492922;
-			
-			// aapt resource value: 0x7F0C003B
-			public static int ua_rate_app_action_default_rate_positive_button = 2131492923;
-			
-			// aapt resource value: 0x7F0C003C
-			public static int ua_rate_app_action_default_title = 2131492924;
-			
-			// aapt resource value: 0x7F0C003D
-			public static int ua_rate_app_action_generic_display_name = 2131492925;
-			
-			// aapt resource value: 0x7F0C003E
-			public static int ua_refresh = 2131492926;
-			
-			// aapt resource value: 0x7F0C003F
-			public static int ua_retry_button = 2131492927;
-			
-			// aapt resource value: 0x7F0C0040
-			public static int ua_select_all = 2131492928;
-			
-			// aapt resource value: 0x7F0C0041
-			public static int ua_select_none = 2131492929;
-			
-			// aapt resource value: 0x7F0C0042
-			public static int ua_service_channel_description = 2131492930;
-			
-			// aapt resource value: 0x7F0C0043
-			public static int ua_service_channel_id = 2131492931;
-			
-			// aapt resource value: 0x7F0C0044
-			public static int ua_service_channel_name = 2131492932;
-			
-			// aapt resource value: 0x7F0C0045
-			public static int ua_share_dialog_title = 2131492933;
-			
-			// aapt resource value: 0x7F0C0046
-			public static int ua_urgent_channel_description = 2131492934;
-			
-			// aapt resource value: 0x7F0C0047
-			public static int ua_urgent_channel_id = 2131492935;
-			
-			// aapt resource value: 0x7F0C0048
-			public static int ua_urgent_channel_name = 2131492936;
+			public static int status_bar_notification_info_overflow = 2131492918;
 			
 			static String()
 			{
@@ -775,289 +4156,1516 @@ namespace AirshipBindings.NETStandard
 		{
 			
 			// aapt resource value: 0x7F0D0000
-			public static int Base_Widget_UrbanAirship_MessageCenter_Item_CheckBox = 2131558400;
+			public static int AlertDialog_AppCompat = 2131558400;
 			
 			// aapt resource value: 0x7F0D0001
-			public static int Base_Widget_UrbanAirship_MessageCenter_Item_Container = 2131558401;
+			public static int AlertDialog_AppCompat_Light = 2131558401;
 			
 			// aapt resource value: 0x7F0D0002
-			public static int Base_Widget_UrbanAirship_MessageCenter_Item_Date = 2131558402;
+			public static int Animation_AppCompat_Dialog = 2131558402;
 			
 			// aapt resource value: 0x7F0D0003
-			public static int Base_Widget_UrbanAirship_MessageCenter_Item_Icon = 2131558403;
+			public static int Animation_AppCompat_DropDownUp = 2131558403;
 			
 			// aapt resource value: 0x7F0D0004
-			public static int Base_Widget_UrbanAirship_MessageCenter_Item_Title = 2131558404;
+			public static int Animation_AppCompat_Tooltip = 2131558404;
 			
 			// aapt resource value: 0x7F0D0005
-			public static int MessageCenter = 2131558405;
+			public static int Animation_Design_BottomSheetDialog = 2131558405;
 			
 			// aapt resource value: 0x7F0D0006
-			public static int MessageCenter_EmptyMessage_TextAppearance = 2131558406;
+			public static int AppCompatDialogStyle = 2131558406;
 			
 			// aapt resource value: 0x7F0D0007
-			public static int MessageCenter_Item_Date_TextAppearance = 2131558407;
+			public static int Base_AlertDialog_AppCompat = 2131558407;
 			
 			// aapt resource value: 0x7F0D0008
-			public static int MessageCenter_Item_Title_TextAppearance = 2131558408;
+			public static int Base_AlertDialog_AppCompat_Light = 2131558408;
 			
 			// aapt resource value: 0x7F0D0009
-			public static int MessageCenter_MessageNotSelected_TextAppearance = 2131558409;
+			public static int Base_Animation_AppCompat_Dialog = 2131558409;
 			
 			// aapt resource value: 0x7F0D000A
-			public static int UrbanAirship = 2131558410;
+			public static int Base_Animation_AppCompat_DropDownUp = 2131558410;
 			
 			// aapt resource value: 0x7F0D000B
-			public static int UrbanAirship_HelperActivity = 2131558411;
+			public static int Base_Animation_AppCompat_Tooltip = 2131558411;
 			
 			// aapt resource value: 0x7F0D000C
-			public static int UrbanAirship_InAppBanner = 2131558412;
-			
-			// aapt resource value: 0x7F0D000D
-			public static int UrbanAirship_InAppBanner_Body = 2131558413;
+			public static int Base_CardView = 2131558412;
 			
 			// aapt resource value: 0x7F0D000E
-			public static int UrbanAirship_InAppBanner_Button = 2131558414;
+			public static int Base_DialogWindowTitleBackground_AppCompat = 2131558414;
+			
+			// aapt resource value: 0x7F0D000D
+			public static int Base_DialogWindowTitle_AppCompat = 2131558413;
 			
 			// aapt resource value: 0x7F0D000F
-			public static int UrbanAirship_InAppBanner_ButtonLayout = 2131558415;
+			public static int Base_TextAppearance_AppCompat = 2131558415;
 			
 			// aapt resource value: 0x7F0D0010
-			public static int UrbanAirship_InAppBanner_Heading = 2131558416;
+			public static int Base_TextAppearance_AppCompat_Body1 = 2131558416;
 			
 			// aapt resource value: 0x7F0D0011
-			public static int UrbanAirship_InAppBanner_Layout = 2131558417;
+			public static int Base_TextAppearance_AppCompat_Body2 = 2131558417;
 			
 			// aapt resource value: 0x7F0D0012
-			public static int UrbanAirship_InAppBanner_Layout_Bottom = 2131558418;
+			public static int Base_TextAppearance_AppCompat_Button = 2131558418;
 			
 			// aapt resource value: 0x7F0D0013
-			public static int UrbanAirship_InAppBanner_Layout_Top = 2131558419;
+			public static int Base_TextAppearance_AppCompat_Caption = 2131558419;
 			
 			// aapt resource value: 0x7F0D0014
-			public static int UrbanAirship_InAppBanner_MediaView = 2131558420;
+			public static int Base_TextAppearance_AppCompat_Display1 = 2131558420;
 			
 			// aapt resource value: 0x7F0D0015
-			public static int UrbanAirship_InAppBanner_MediaView_Left = 2131558421;
+			public static int Base_TextAppearance_AppCompat_Display2 = 2131558421;
 			
 			// aapt resource value: 0x7F0D0016
-			public static int UrbanAirship_InAppBanner_MediaView_Right = 2131558422;
+			public static int Base_TextAppearance_AppCompat_Display3 = 2131558422;
 			
 			// aapt resource value: 0x7F0D0017
-			public static int UrbanAirship_InAppBanner_Pull = 2131558423;
+			public static int Base_TextAppearance_AppCompat_Display4 = 2131558423;
 			
 			// aapt resource value: 0x7F0D0018
-			public static int UrbanAirship_InAppBanner_Pull_Bottom = 2131558424;
+			public static int Base_TextAppearance_AppCompat_Headline = 2131558424;
 			
 			// aapt resource value: 0x7F0D0019
-			public static int UrbanAirship_InAppBanner_Pull_Top = 2131558425;
+			public static int Base_TextAppearance_AppCompat_Inverse = 2131558425;
 			
 			// aapt resource value: 0x7F0D001A
-			public static int UrbanAirship_InAppFullscreen = 2131558426;
+			public static int Base_TextAppearance_AppCompat_Large = 2131558426;
 			
 			// aapt resource value: 0x7F0D001B
-			public static int UrbanAirship_InAppFullscreen_Activity = 2131558427;
+			public static int Base_TextAppearance_AppCompat_Large_Inverse = 2131558427;
 			
 			// aapt resource value: 0x7F0D001C
-			public static int UrbanAirship_InAppFullscreen_Body = 2131558428;
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131558428;
 			
 			// aapt resource value: 0x7F0D001D
-			public static int UrbanAirship_InAppFullscreen_Body_HeaderBodyMedia = 2131558429;
+			public static int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131558429;
 			
 			// aapt resource value: 0x7F0D001E
-			public static int UrbanAirship_InAppFullscreen_Body_HeaderMediaBody = 2131558430;
+			public static int Base_TextAppearance_AppCompat_Medium = 2131558430;
 			
 			// aapt resource value: 0x7F0D001F
-			public static int UrbanAirship_InAppFullscreen_Body_MediaHeaderBody = 2131558431;
+			public static int Base_TextAppearance_AppCompat_Medium_Inverse = 2131558431;
 			
 			// aapt resource value: 0x7F0D0020
-			public static int UrbanAirship_InAppFullscreen_Button = 2131558432;
+			public static int Base_TextAppearance_AppCompat_Menu = 2131558432;
 			
 			// aapt resource value: 0x7F0D0021
-			public static int UrbanAirship_InAppFullscreen_ButtonLayout = 2131558433;
+			public static int Base_TextAppearance_AppCompat_SearchResult = 2131558433;
 			
 			// aapt resource value: 0x7F0D0022
-			public static int UrbanAirship_InAppFullscreen_DismissButton = 2131558434;
+			public static int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131558434;
 			
 			// aapt resource value: 0x7F0D0023
-			public static int UrbanAirship_InAppFullscreen_DismissButtonHolder = 2131558435;
+			public static int Base_TextAppearance_AppCompat_SearchResult_Title = 2131558435;
 			
 			// aapt resource value: 0x7F0D0024
-			public static int UrbanAirship_InAppFullscreen_Footer = 2131558436;
+			public static int Base_TextAppearance_AppCompat_Small = 2131558436;
 			
 			// aapt resource value: 0x7F0D0025
-			public static int UrbanAirship_InAppFullscreen_FooterHolder = 2131558437;
+			public static int Base_TextAppearance_AppCompat_Small_Inverse = 2131558437;
 			
 			// aapt resource value: 0x7F0D0026
-			public static int UrbanAirship_InAppFullscreen_Heading = 2131558438;
+			public static int Base_TextAppearance_AppCompat_Subhead = 2131558438;
 			
 			// aapt resource value: 0x7F0D0027
-			public static int UrbanAirship_InAppFullscreen_Heading_HeaderBodyMedia = 2131558439;
+			public static int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131558439;
 			
 			// aapt resource value: 0x7F0D0028
-			public static int UrbanAirship_InAppFullscreen_Heading_HeaderMediaBody = 2131558440;
+			public static int Base_TextAppearance_AppCompat_Title = 2131558440;
 			
 			// aapt resource value: 0x7F0D0029
-			public static int UrbanAirship_InAppFullscreen_Heading_MediaHeaderBody = 2131558441;
+			public static int Base_TextAppearance_AppCompat_Title_Inverse = 2131558441;
 			
 			// aapt resource value: 0x7F0D002A
-			public static int UrbanAirship_InAppFullscreen_Layout = 2131558442;
+			public static int Base_TextAppearance_AppCompat_Tooltip = 2131558442;
 			
 			// aapt resource value: 0x7F0D002B
-			public static int UrbanAirship_InAppFullscreen_Layout_HeaderBodyMedia = 2131558443;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131558443;
 			
 			// aapt resource value: 0x7F0D002C
-			public static int UrbanAirship_InAppFullscreen_Layout_HeaderMediaBody = 2131558444;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131558444;
 			
 			// aapt resource value: 0x7F0D002D
-			public static int UrbanAirship_InAppFullscreen_Layout_MediaHeaderBody = 2131558445;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131558445;
 			
 			// aapt resource value: 0x7F0D002E
-			public static int UrbanAirship_InAppFullscreen_MediaView = 2131558446;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131558446;
 			
 			// aapt resource value: 0x7F0D002F
-			public static int UrbanAirship_InAppFullscreen_MediaView_HeaderBodyMedia = 2131558447;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131558447;
 			
 			// aapt resource value: 0x7F0D0030
-			public static int UrbanAirship_InAppFullscreen_MediaView_HeaderMediaBody = 2131558448;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131558448;
 			
 			// aapt resource value: 0x7F0D0031
-			public static int UrbanAirship_InAppFullscreen_MediaView_MediaHeaderBody = 2131558449;
+			public static int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131558449;
 			
 			// aapt resource value: 0x7F0D0032
-			public static int UrbanAirship_InAppFullscreen_ScrollView = 2131558450;
+			public static int Base_TextAppearance_AppCompat_Widget_Button = 2131558450;
 			
 			// aapt resource value: 0x7F0D0033
-			public static int UrbanAirship_InAppHtml = 2131558451;
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131558451;
 			
 			// aapt resource value: 0x7F0D0034
-			public static int UrbanAirship_InAppHtml_Activity = 2131558452;
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Colored = 2131558452;
 			
 			// aapt resource value: 0x7F0D0035
-			public static int UrbanAirship_InAppHtml_Activity_Fullscreen = 2131558453;
+			public static int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131558453;
 			
 			// aapt resource value: 0x7F0D0036
-			public static int UrbanAirship_InAppHtml_Content = 2131558454;
+			public static int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131558454;
 			
 			// aapt resource value: 0x7F0D0037
-			public static int UrbanAirship_InAppHtml_Content_Fullscreen = 2131558455;
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131558455;
 			
 			// aapt resource value: 0x7F0D0038
-			public static int UrbanAirship_InAppHtml_DismissButton = 2131558456;
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131558456;
 			
 			// aapt resource value: 0x7F0D0039
-			public static int UrbanAirship_InAppHtml_Layout = 2131558457;
+			public static int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131558457;
 			
 			// aapt resource value: 0x7F0D003A
-			public static int UrbanAirship_InAppHtml_Layout_Fullscreen = 2131558458;
+			public static int Base_TextAppearance_AppCompat_Widget_Switch = 2131558458;
 			
 			// aapt resource value: 0x7F0D003B
-			public static int UrbanAirship_InAppHtml_Progress = 2131558459;
+			public static int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131558459;
 			
 			// aapt resource value: 0x7F0D003C
-			public static int UrbanAirship_InAppHtml_WebView = 2131558460;
+			public static int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131558460;
 			
 			// aapt resource value: 0x7F0D003D
-			public static int UrbanAirship_InAppModal = 2131558461;
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131558461;
 			
 			// aapt resource value: 0x7F0D003E
-			public static int UrbanAirship_InAppModal_Activity = 2131558462;
-			
-			// aapt resource value: 0x7F0D003F
-			public static int UrbanAirship_InAppModal_Activity_Fullscreen = 2131558463;
-			
-			// aapt resource value: 0x7F0D0040
-			public static int UrbanAirship_InAppModal_Body = 2131558464;
-			
-			// aapt resource value: 0x7F0D0041
-			public static int UrbanAirship_InAppModal_Body_HeaderBodyMedia = 2131558465;
-			
-			// aapt resource value: 0x7F0D0042
-			public static int UrbanAirship_InAppModal_Body_HeaderMediaBody = 2131558466;
-			
-			// aapt resource value: 0x7F0D0043
-			public static int UrbanAirship_InAppModal_Body_MediaHeaderBody = 2131558467;
-			
-			// aapt resource value: 0x7F0D0044
-			public static int UrbanAirship_InAppModal_Button = 2131558468;
-			
-			// aapt resource value: 0x7F0D0045
-			public static int UrbanAirship_InAppModal_ButtonLayout = 2131558469;
-			
-			// aapt resource value: 0x7F0D0046
-			public static int UrbanAirship_InAppModal_Content = 2131558470;
-			
-			// aapt resource value: 0x7F0D0047
-			public static int UrbanAirship_InAppModal_Content_HeaderBodyMedia = 2131558471;
-			
-			// aapt resource value: 0x7F0D0048
-			public static int UrbanAirship_InAppModal_Content_HeaderMediaBody = 2131558472;
-			
-			// aapt resource value: 0x7F0D0049
-			public static int UrbanAirship_InAppModal_Content_MediaHeaderBody = 2131558473;
-			
-			// aapt resource value: 0x7F0D004A
-			public static int UrbanAirship_InAppModal_DismissButton = 2131558474;
-			
-			// aapt resource value: 0x7F0D004B
-			public static int UrbanAirship_InAppModal_DismissButton_Fullscreen = 2131558475;
-			
-			// aapt resource value: 0x7F0D004C
-			public static int UrbanAirship_InAppModal_Footer = 2131558476;
-			
-			// aapt resource value: 0x7F0D004D
-			public static int UrbanAirship_InAppModal_FooterHolder = 2131558477;
-			
-			// aapt resource value: 0x7F0D004E
-			public static int UrbanAirship_InAppModal_Heading = 2131558478;
-			
-			// aapt resource value: 0x7F0D004F
-			public static int UrbanAirship_InAppModal_Heading_HeaderBodyMedia = 2131558479;
-			
-			// aapt resource value: 0x7F0D0050
-			public static int UrbanAirship_InAppModal_Heading_HeaderMediaBody = 2131558480;
-			
-			// aapt resource value: 0x7F0D0051
-			public static int UrbanAirship_InAppModal_Heading_MediaHeaderBody = 2131558481;
-			
-			// aapt resource value: 0x7F0D0052
-			public static int UrbanAirship_InAppModal_Layout = 2131558482;
-			
-			// aapt resource value: 0x7F0D0053
-			public static int UrbanAirship_InAppModal_Layout_Fullscreen = 2131558483;
-			
-			// aapt resource value: 0x7F0D0054
-			public static int UrbanAirship_InAppModal_MediaView = 2131558484;
-			
-			// aapt resource value: 0x7F0D0055
-			public static int UrbanAirship_InAppModal_MediaView_HeaderBodyMedia = 2131558485;
-			
-			// aapt resource value: 0x7F0D0056
-			public static int UrbanAirship_InAppModal_MediaView_HeaderMediaBody = 2131558486;
-			
-			// aapt resource value: 0x7F0D0057
-			public static int UrbanAirship_InAppModal_MediaView_MediaHeaderBody = 2131558487;
-			
-			// aapt resource value: 0x7F0D0058
-			public static int UrbanAirship_InAppModal_ScrollView = 2131558488;
-			
-			// aapt resource value: 0x7F0D0059
-			public static int UrbanAirship_RateAppActivity = 2131558489;
-			
-			// aapt resource value: 0x7F0D005A
-			public static int Widget_UrbanAirship_MessageCenter_Item_CheckBox = 2131558490;
-			
-			// aapt resource value: 0x7F0D005B
-			public static int Widget_UrbanAirship_MessageCenter_Item_Container = 2131558491;
-			
-			// aapt resource value: 0x7F0D005C
-			public static int Widget_UrbanAirship_MessageCenter_Item_Date = 2131558492;
-			
-			// aapt resource value: 0x7F0D005D
-			public static int Widget_UrbanAirship_MessageCenter_Item_Icon = 2131558493;
+			public static int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131558462;
 			
 			// aapt resource value: 0x7F0D005E
-			public static int Widget_UrbanAirship_MessageCenter_Item_Title = 2131558494;
+			public static int Base_ThemeOverlay_AppCompat = 2131558494;
+			
+			// aapt resource value: 0x7F0D005F
+			public static int Base_ThemeOverlay_AppCompat_ActionBar = 2131558495;
+			
+			// aapt resource value: 0x7F0D0060
+			public static int Base_ThemeOverlay_AppCompat_Dark = 2131558496;
+			
+			// aapt resource value: 0x7F0D0061
+			public static int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131558497;
+			
+			// aapt resource value: 0x7F0D0062
+			public static int Base_ThemeOverlay_AppCompat_Dialog = 2131558498;
+			
+			// aapt resource value: 0x7F0D0063
+			public static int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131558499;
+			
+			// aapt resource value: 0x7F0D0064
+			public static int Base_ThemeOverlay_AppCompat_Light = 2131558500;
+			
+			// aapt resource value: 0x7F0D0065
+			public static int Base_ThemeOverlay_MaterialComponents_Dialog = 2131558501;
+			
+			// aapt resource value: 0x7F0D0066
+			public static int Base_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131558502;
+			
+			// aapt resource value: 0x7F0D003F
+			public static int Base_Theme_AppCompat = 2131558463;
+			
+			// aapt resource value: 0x7F0D0040
+			public static int Base_Theme_AppCompat_CompactMenu = 2131558464;
+			
+			// aapt resource value: 0x7F0D0041
+			public static int Base_Theme_AppCompat_Dialog = 2131558465;
+			
+			// aapt resource value: 0x7F0D0045
+			public static int Base_Theme_AppCompat_DialogWhenLarge = 2131558469;
+			
+			// aapt resource value: 0x7F0D0042
+			public static int Base_Theme_AppCompat_Dialog_Alert = 2131558466;
+			
+			// aapt resource value: 0x7F0D0043
+			public static int Base_Theme_AppCompat_Dialog_FixedSize = 2131558467;
+			
+			// aapt resource value: 0x7F0D0044
+			public static int Base_Theme_AppCompat_Dialog_MinWidth = 2131558468;
+			
+			// aapt resource value: 0x7F0D0046
+			public static int Base_Theme_AppCompat_Light = 2131558470;
+			
+			// aapt resource value: 0x7F0D0047
+			public static int Base_Theme_AppCompat_Light_DarkActionBar = 2131558471;
+			
+			// aapt resource value: 0x7F0D0048
+			public static int Base_Theme_AppCompat_Light_Dialog = 2131558472;
+			
+			// aapt resource value: 0x7F0D004C
+			public static int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131558476;
+			
+			// aapt resource value: 0x7F0D0049
+			public static int Base_Theme_AppCompat_Light_Dialog_Alert = 2131558473;
+			
+			// aapt resource value: 0x7F0D004A
+			public static int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131558474;
+			
+			// aapt resource value: 0x7F0D004B
+			public static int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131558475;
+			
+			// aapt resource value: 0x7F0D004D
+			public static int Base_Theme_MaterialComponents = 2131558477;
+			
+			// aapt resource value: 0x7F0D004E
+			public static int Base_Theme_MaterialComponents_Bridge = 2131558478;
+			
+			// aapt resource value: 0x7F0D004F
+			public static int Base_Theme_MaterialComponents_CompactMenu = 2131558479;
+			
+			// aapt resource value: 0x7F0D0050
+			public static int Base_Theme_MaterialComponents_Dialog = 2131558480;
+			
+			// aapt resource value: 0x7F0D0054
+			public static int Base_Theme_MaterialComponents_DialogWhenLarge = 2131558484;
+			
+			// aapt resource value: 0x7F0D0051
+			public static int Base_Theme_MaterialComponents_Dialog_Alert = 2131558481;
+			
+			// aapt resource value: 0x7F0D0052
+			public static int Base_Theme_MaterialComponents_Dialog_FixedSize = 2131558482;
+			
+			// aapt resource value: 0x7F0D0053
+			public static int Base_Theme_MaterialComponents_Dialog_MinWidth = 2131558483;
+			
+			// aapt resource value: 0x7F0D0055
+			public static int Base_Theme_MaterialComponents_Light = 2131558485;
+			
+			// aapt resource value: 0x7F0D0056
+			public static int Base_Theme_MaterialComponents_Light_Bridge = 2131558486;
+			
+			// aapt resource value: 0x7F0D0057
+			public static int Base_Theme_MaterialComponents_Light_DarkActionBar = 2131558487;
+			
+			// aapt resource value: 0x7F0D0058
+			public static int Base_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131558488;
+			
+			// aapt resource value: 0x7F0D0059
+			public static int Base_Theme_MaterialComponents_Light_Dialog = 2131558489;
+			
+			// aapt resource value: 0x7F0D005D
+			public static int Base_Theme_MaterialComponents_Light_DialogWhenLarge = 2131558493;
+			
+			// aapt resource value: 0x7F0D005A
+			public static int Base_Theme_MaterialComponents_Light_Dialog_Alert = 2131558490;
+			
+			// aapt resource value: 0x7F0D005B
+			public static int Base_Theme_MaterialComponents_Light_Dialog_FixedSize = 2131558491;
+			
+			// aapt resource value: 0x7F0D005C
+			public static int Base_Theme_MaterialComponents_Light_Dialog_MinWidth = 2131558492;
+			
+			// aapt resource value: 0x7F0D006E
+			public static int Base_V14_ThemeOverlay_MaterialComponents_Dialog = 2131558510;
+			
+			// aapt resource value: 0x7F0D006F
+			public static int Base_V14_ThemeOverlay_MaterialComponents_Dialog_Alert = 2131558511;
+			
+			// aapt resource value: 0x7F0D0067
+			public static int Base_V14_Theme_MaterialComponents = 2131558503;
+			
+			// aapt resource value: 0x7F0D0068
+			public static int Base_V14_Theme_MaterialComponents_Bridge = 2131558504;
+			
+			// aapt resource value: 0x7F0D0069
+			public static int Base_V14_Theme_MaterialComponents_Dialog = 2131558505;
+			
+			// aapt resource value: 0x7F0D006A
+			public static int Base_V14_Theme_MaterialComponents_Light = 2131558506;
+			
+			// aapt resource value: 0x7F0D006B
+			public static int Base_V14_Theme_MaterialComponents_Light_Bridge = 2131558507;
+			
+			// aapt resource value: 0x7F0D006C
+			public static int Base_V14_Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131558508;
+			
+			// aapt resource value: 0x7F0D006D
+			public static int Base_V14_Theme_MaterialComponents_Light_Dialog = 2131558509;
+			
+			// aapt resource value: 0x7F0D0074
+			public static int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131558516;
+			
+			// aapt resource value: 0x7F0D0070
+			public static int Base_V21_Theme_AppCompat = 2131558512;
+			
+			// aapt resource value: 0x7F0D0071
+			public static int Base_V21_Theme_AppCompat_Dialog = 2131558513;
+			
+			// aapt resource value: 0x7F0D0072
+			public static int Base_V21_Theme_AppCompat_Light = 2131558514;
+			
+			// aapt resource value: 0x7F0D0073
+			public static int Base_V21_Theme_AppCompat_Light_Dialog = 2131558515;
+			
+			// aapt resource value: 0x7F0D0075
+			public static int Base_V22_Theme_AppCompat = 2131558517;
+			
+			// aapt resource value: 0x7F0D0076
+			public static int Base_V22_Theme_AppCompat_Light = 2131558518;
+			
+			// aapt resource value: 0x7F0D0077
+			public static int Base_V23_Theme_AppCompat = 2131558519;
+			
+			// aapt resource value: 0x7F0D0078
+			public static int Base_V23_Theme_AppCompat_Light = 2131558520;
+			
+			// aapt resource value: 0x7F0D0079
+			public static int Base_V26_Theme_AppCompat = 2131558521;
+			
+			// aapt resource value: 0x7F0D007A
+			public static int Base_V26_Theme_AppCompat_Light = 2131558522;
+			
+			// aapt resource value: 0x7F0D007B
+			public static int Base_V26_Widget_AppCompat_Toolbar = 2131558523;
+			
+			// aapt resource value: 0x7F0D007C
+			public static int Base_V28_Theme_AppCompat = 2131558524;
+			
+			// aapt resource value: 0x7F0D007D
+			public static int Base_V28_Theme_AppCompat_Light = 2131558525;
+			
+			// aapt resource value: 0x7F0D0082
+			public static int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131558530;
+			
+			// aapt resource value: 0x7F0D007E
+			public static int Base_V7_Theme_AppCompat = 2131558526;
+			
+			// aapt resource value: 0x7F0D007F
+			public static int Base_V7_Theme_AppCompat_Dialog = 2131558527;
+			
+			// aapt resource value: 0x7F0D0080
+			public static int Base_V7_Theme_AppCompat_Light = 2131558528;
+			
+			// aapt resource value: 0x7F0D0081
+			public static int Base_V7_Theme_AppCompat_Light_Dialog = 2131558529;
+			
+			// aapt resource value: 0x7F0D0083
+			public static int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131558531;
+			
+			// aapt resource value: 0x7F0D0084
+			public static int Base_V7_Widget_AppCompat_EditText = 2131558532;
+			
+			// aapt resource value: 0x7F0D0085
+			public static int Base_V7_Widget_AppCompat_Toolbar = 2131558533;
+			
+			// aapt resource value: 0x7F0D0086
+			public static int Base_Widget_AppCompat_ActionBar = 2131558534;
+			
+			// aapt resource value: 0x7F0D0087
+			public static int Base_Widget_AppCompat_ActionBar_Solid = 2131558535;
+			
+			// aapt resource value: 0x7F0D0088
+			public static int Base_Widget_AppCompat_ActionBar_TabBar = 2131558536;
+			
+			// aapt resource value: 0x7F0D0089
+			public static int Base_Widget_AppCompat_ActionBar_TabText = 2131558537;
+			
+			// aapt resource value: 0x7F0D008A
+			public static int Base_Widget_AppCompat_ActionBar_TabView = 2131558538;
+			
+			// aapt resource value: 0x7F0D008B
+			public static int Base_Widget_AppCompat_ActionButton = 2131558539;
+			
+			// aapt resource value: 0x7F0D008C
+			public static int Base_Widget_AppCompat_ActionButton_CloseMode = 2131558540;
+			
+			// aapt resource value: 0x7F0D008D
+			public static int Base_Widget_AppCompat_ActionButton_Overflow = 2131558541;
+			
+			// aapt resource value: 0x7F0D008E
+			public static int Base_Widget_AppCompat_ActionMode = 2131558542;
+			
+			// aapt resource value: 0x7F0D008F
+			public static int Base_Widget_AppCompat_ActivityChooserView = 2131558543;
+			
+			// aapt resource value: 0x7F0D0090
+			public static int Base_Widget_AppCompat_AutoCompleteTextView = 2131558544;
+			
+			// aapt resource value: 0x7F0D0091
+			public static int Base_Widget_AppCompat_Button = 2131558545;
+			
+			// aapt resource value: 0x7F0D0097
+			public static int Base_Widget_AppCompat_ButtonBar = 2131558551;
+			
+			// aapt resource value: 0x7F0D0098
+			public static int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131558552;
+			
+			// aapt resource value: 0x7F0D0092
+			public static int Base_Widget_AppCompat_Button_Borderless = 2131558546;
+			
+			// aapt resource value: 0x7F0D0093
+			public static int Base_Widget_AppCompat_Button_Borderless_Colored = 2131558547;
+			
+			// aapt resource value: 0x7F0D0094
+			public static int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131558548;
+			
+			// aapt resource value: 0x7F0D0095
+			public static int Base_Widget_AppCompat_Button_Colored = 2131558549;
+			
+			// aapt resource value: 0x7F0D0096
+			public static int Base_Widget_AppCompat_Button_Small = 2131558550;
+			
+			// aapt resource value: 0x7F0D0099
+			public static int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131558553;
+			
+			// aapt resource value: 0x7F0D009A
+			public static int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131558554;
+			
+			// aapt resource value: 0x7F0D009B
+			public static int Base_Widget_AppCompat_CompoundButton_Switch = 2131558555;
+			
+			// aapt resource value: 0x7F0D009C
+			public static int Base_Widget_AppCompat_DrawerArrowToggle = 2131558556;
+			
+			// aapt resource value: 0x7F0D009D
+			public static int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131558557;
+			
+			// aapt resource value: 0x7F0D009E
+			public static int Base_Widget_AppCompat_DropDownItem_Spinner = 2131558558;
+			
+			// aapt resource value: 0x7F0D009F
+			public static int Base_Widget_AppCompat_EditText = 2131558559;
+			
+			// aapt resource value: 0x7F0D00A0
+			public static int Base_Widget_AppCompat_ImageButton = 2131558560;
+			
+			// aapt resource value: 0x7F0D00A1
+			public static int Base_Widget_AppCompat_Light_ActionBar = 2131558561;
+			
+			// aapt resource value: 0x7F0D00A2
+			public static int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131558562;
+			
+			// aapt resource value: 0x7F0D00A3
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131558563;
+			
+			// aapt resource value: 0x7F0D00A4
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131558564;
+			
+			// aapt resource value: 0x7F0D00A5
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131558565;
+			
+			// aapt resource value: 0x7F0D00A6
+			public static int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131558566;
+			
+			// aapt resource value: 0x7F0D00A7
+			public static int Base_Widget_AppCompat_Light_PopupMenu = 2131558567;
+			
+			// aapt resource value: 0x7F0D00A8
+			public static int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131558568;
+			
+			// aapt resource value: 0x7F0D00A9
+			public static int Base_Widget_AppCompat_ListMenuView = 2131558569;
+			
+			// aapt resource value: 0x7F0D00AA
+			public static int Base_Widget_AppCompat_ListPopupWindow = 2131558570;
+			
+			// aapt resource value: 0x7F0D00AB
+			public static int Base_Widget_AppCompat_ListView = 2131558571;
+			
+			// aapt resource value: 0x7F0D00AC
+			public static int Base_Widget_AppCompat_ListView_DropDown = 2131558572;
+			
+			// aapt resource value: 0x7F0D00AD
+			public static int Base_Widget_AppCompat_ListView_Menu = 2131558573;
+			
+			// aapt resource value: 0x7F0D00AE
+			public static int Base_Widget_AppCompat_PopupMenu = 2131558574;
+			
+			// aapt resource value: 0x7F0D00AF
+			public static int Base_Widget_AppCompat_PopupMenu_Overflow = 2131558575;
+			
+			// aapt resource value: 0x7F0D00B0
+			public static int Base_Widget_AppCompat_PopupWindow = 2131558576;
+			
+			// aapt resource value: 0x7F0D00B1
+			public static int Base_Widget_AppCompat_ProgressBar = 2131558577;
+			
+			// aapt resource value: 0x7F0D00B2
+			public static int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131558578;
+			
+			// aapt resource value: 0x7F0D00B3
+			public static int Base_Widget_AppCompat_RatingBar = 2131558579;
+			
+			// aapt resource value: 0x7F0D00B4
+			public static int Base_Widget_AppCompat_RatingBar_Indicator = 2131558580;
+			
+			// aapt resource value: 0x7F0D00B5
+			public static int Base_Widget_AppCompat_RatingBar_Small = 2131558581;
+			
+			// aapt resource value: 0x7F0D00B6
+			public static int Base_Widget_AppCompat_SearchView = 2131558582;
+			
+			// aapt resource value: 0x7F0D00B7
+			public static int Base_Widget_AppCompat_SearchView_ActionBar = 2131558583;
+			
+			// aapt resource value: 0x7F0D00B8
+			public static int Base_Widget_AppCompat_SeekBar = 2131558584;
+			
+			// aapt resource value: 0x7F0D00B9
+			public static int Base_Widget_AppCompat_SeekBar_Discrete = 2131558585;
+			
+			// aapt resource value: 0x7F0D00BA
+			public static int Base_Widget_AppCompat_Spinner = 2131558586;
+			
+			// aapt resource value: 0x7F0D00BB
+			public static int Base_Widget_AppCompat_Spinner_Underlined = 2131558587;
+			
+			// aapt resource value: 0x7F0D00BC
+			public static int Base_Widget_AppCompat_TextView_SpinnerItem = 2131558588;
+			
+			// aapt resource value: 0x7F0D00BD
+			public static int Base_Widget_AppCompat_Toolbar = 2131558589;
+			
+			// aapt resource value: 0x7F0D00BE
+			public static int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131558590;
+			
+			// aapt resource value: 0x7F0D00BF
+			public static int Base_Widget_Design_TabLayout = 2131558591;
+			
+			// aapt resource value: 0x7F0D00C0
+			public static int Base_Widget_MaterialComponents_Chip = 2131558592;
+			
+			// aapt resource value: 0x7F0D00C1
+			public static int Base_Widget_MaterialComponents_TextInputEditText = 2131558593;
+			
+			// aapt resource value: 0x7F0D00C2
+			public static int Base_Widget_MaterialComponents_TextInputLayout = 2131558594;
+			
+			// aapt resource value: 0x7F0D00C3
+			public static int CardView = 2131558595;
+			
+			// aapt resource value: 0x7F0D00C4
+			public static int CardView_Dark = 2131558596;
+			
+			// aapt resource value: 0x7F0D00C5
+			public static int CardView_Light = 2131558597;
+			
+			// aapt resource value: 0x7F0D01F7
+			public static int collectionViewStyle = 2131558903;
+			
+			// aapt resource value: 0x7F0D00C6
+			public static int MainTheme = 2131558598;
+			
+			// aapt resource value: 0x7F0D00C7
+			public static int MainTheme_Base = 2131558599;
+			
+			// aapt resource value: 0x7F0D00C8
+			public static int Platform_AppCompat = 2131558600;
+			
+			// aapt resource value: 0x7F0D00C9
+			public static int Platform_AppCompat_Light = 2131558601;
+			
+			// aapt resource value: 0x7F0D00CA
+			public static int Platform_MaterialComponents = 2131558602;
+			
+			// aapt resource value: 0x7F0D00CB
+			public static int Platform_MaterialComponents_Dialog = 2131558603;
+			
+			// aapt resource value: 0x7F0D00CC
+			public static int Platform_MaterialComponents_Light = 2131558604;
+			
+			// aapt resource value: 0x7F0D00CD
+			public static int Platform_MaterialComponents_Light_Dialog = 2131558605;
+			
+			// aapt resource value: 0x7F0D00CE
+			public static int Platform_ThemeOverlay_AppCompat = 2131558606;
+			
+			// aapt resource value: 0x7F0D00CF
+			public static int Platform_ThemeOverlay_AppCompat_Dark = 2131558607;
+			
+			// aapt resource value: 0x7F0D00D0
+			public static int Platform_ThemeOverlay_AppCompat_Light = 2131558608;
+			
+			// aapt resource value: 0x7F0D00D1
+			public static int Platform_V21_AppCompat = 2131558609;
+			
+			// aapt resource value: 0x7F0D00D2
+			public static int Platform_V21_AppCompat_Light = 2131558610;
+			
+			// aapt resource value: 0x7F0D00D3
+			public static int Platform_V25_AppCompat = 2131558611;
+			
+			// aapt resource value: 0x7F0D00D4
+			public static int Platform_V25_AppCompat_Light = 2131558612;
+			
+			// aapt resource value: 0x7F0D00D5
+			public static int Platform_Widget_AppCompat_Spinner = 2131558613;
+			
+			// aapt resource value: 0x7F0D00D6
+			public static int RtlOverlay_DialogWindowTitle_AppCompat = 2131558614;
+			
+			// aapt resource value: 0x7F0D00D7
+			public static int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131558615;
+			
+			// aapt resource value: 0x7F0D00D8
+			public static int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131558616;
+			
+			// aapt resource value: 0x7F0D00D9
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131558617;
+			
+			// aapt resource value: 0x7F0D00DA
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131558618;
+			
+			// aapt resource value: 0x7F0D00DB
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Shortcut = 2131558619;
+			
+			// aapt resource value: 0x7F0D00DC
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_SubmenuArrow = 2131558620;
+			
+			// aapt resource value: 0x7F0D00DD
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131558621;
+			
+			// aapt resource value: 0x7F0D00DE
+			public static int RtlOverlay_Widget_AppCompat_PopupMenuItem_Title = 2131558622;
+			
+			// aapt resource value: 0x7F0D00E4
+			public static int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131558628;
+			
+			// aapt resource value: 0x7F0D00DF
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131558623;
+			
+			// aapt resource value: 0x7F0D00E0
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131558624;
+			
+			// aapt resource value: 0x7F0D00E1
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131558625;
+			
+			// aapt resource value: 0x7F0D00E2
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131558626;
+			
+			// aapt resource value: 0x7F0D00E3
+			public static int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131558627;
+			
+			// aapt resource value: 0x7F0D00E5
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton = 2131558629;
+			
+			// aapt resource value: 0x7F0D00E6
+			public static int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131558630;
+			
+			// aapt resource value: 0x7F0D00E7
+			public static int TextAppearance_AppCompat = 2131558631;
+			
+			// aapt resource value: 0x7F0D00E8
+			public static int TextAppearance_AppCompat_Body1 = 2131558632;
+			
+			// aapt resource value: 0x7F0D00E9
+			public static int TextAppearance_AppCompat_Body2 = 2131558633;
+			
+			// aapt resource value: 0x7F0D00EA
+			public static int TextAppearance_AppCompat_Button = 2131558634;
+			
+			// aapt resource value: 0x7F0D00EB
+			public static int TextAppearance_AppCompat_Caption = 2131558635;
+			
+			// aapt resource value: 0x7F0D00EC
+			public static int TextAppearance_AppCompat_Display1 = 2131558636;
+			
+			// aapt resource value: 0x7F0D00ED
+			public static int TextAppearance_AppCompat_Display2 = 2131558637;
+			
+			// aapt resource value: 0x7F0D00EE
+			public static int TextAppearance_AppCompat_Display3 = 2131558638;
+			
+			// aapt resource value: 0x7F0D00EF
+			public static int TextAppearance_AppCompat_Display4 = 2131558639;
+			
+			// aapt resource value: 0x7F0D00F0
+			public static int TextAppearance_AppCompat_Headline = 2131558640;
+			
+			// aapt resource value: 0x7F0D00F1
+			public static int TextAppearance_AppCompat_Inverse = 2131558641;
+			
+			// aapt resource value: 0x7F0D00F2
+			public static int TextAppearance_AppCompat_Large = 2131558642;
+			
+			// aapt resource value: 0x7F0D00F3
+			public static int TextAppearance_AppCompat_Large_Inverse = 2131558643;
+			
+			// aapt resource value: 0x7F0D00F4
+			public static int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131558644;
+			
+			// aapt resource value: 0x7F0D00F5
+			public static int TextAppearance_AppCompat_Light_SearchResult_Title = 2131558645;
+			
+			// aapt resource value: 0x7F0D00F6
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131558646;
+			
+			// aapt resource value: 0x7F0D00F7
+			public static int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131558647;
+			
+			// aapt resource value: 0x7F0D00F8
+			public static int TextAppearance_AppCompat_Medium = 2131558648;
+			
+			// aapt resource value: 0x7F0D00F9
+			public static int TextAppearance_AppCompat_Medium_Inverse = 2131558649;
+			
+			// aapt resource value: 0x7F0D00FA
+			public static int TextAppearance_AppCompat_Menu = 2131558650;
+			
+			// aapt resource value: 0x7F0D00FB
+			public static int TextAppearance_AppCompat_SearchResult_Subtitle = 2131558651;
+			
+			// aapt resource value: 0x7F0D00FC
+			public static int TextAppearance_AppCompat_SearchResult_Title = 2131558652;
+			
+			// aapt resource value: 0x7F0D00FD
+			public static int TextAppearance_AppCompat_Small = 2131558653;
+			
+			// aapt resource value: 0x7F0D00FE
+			public static int TextAppearance_AppCompat_Small_Inverse = 2131558654;
+			
+			// aapt resource value: 0x7F0D00FF
+			public static int TextAppearance_AppCompat_Subhead = 2131558655;
+			
+			// aapt resource value: 0x7F0D0100
+			public static int TextAppearance_AppCompat_Subhead_Inverse = 2131558656;
+			
+			// aapt resource value: 0x7F0D0101
+			public static int TextAppearance_AppCompat_Title = 2131558657;
+			
+			// aapt resource value: 0x7F0D0102
+			public static int TextAppearance_AppCompat_Title_Inverse = 2131558658;
+			
+			// aapt resource value: 0x7F0D0103
+			public static int TextAppearance_AppCompat_Tooltip = 2131558659;
+			
+			// aapt resource value: 0x7F0D0104
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131558660;
+			
+			// aapt resource value: 0x7F0D0105
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131558661;
+			
+			// aapt resource value: 0x7F0D0106
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131558662;
+			
+			// aapt resource value: 0x7F0D0107
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131558663;
+			
+			// aapt resource value: 0x7F0D0108
+			public static int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131558664;
+			
+			// aapt resource value: 0x7F0D0109
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131558665;
+			
+			// aapt resource value: 0x7F0D010A
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131558666;
+			
+			// aapt resource value: 0x7F0D010B
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131558667;
+			
+			// aapt resource value: 0x7F0D010C
+			public static int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131558668;
+			
+			// aapt resource value: 0x7F0D010D
+			public static int TextAppearance_AppCompat_Widget_Button = 2131558669;
+			
+			// aapt resource value: 0x7F0D010E
+			public static int TextAppearance_AppCompat_Widget_Button_Borderless_Colored = 2131558670;
+			
+			// aapt resource value: 0x7F0D010F
+			public static int TextAppearance_AppCompat_Widget_Button_Colored = 2131558671;
+			
+			// aapt resource value: 0x7F0D0110
+			public static int TextAppearance_AppCompat_Widget_Button_Inverse = 2131558672;
+			
+			// aapt resource value: 0x7F0D0111
+			public static int TextAppearance_AppCompat_Widget_DropDownItem = 2131558673;
+			
+			// aapt resource value: 0x7F0D0112
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131558674;
+			
+			// aapt resource value: 0x7F0D0113
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131558675;
+			
+			// aapt resource value: 0x7F0D0114
+			public static int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131558676;
+			
+			// aapt resource value: 0x7F0D0115
+			public static int TextAppearance_AppCompat_Widget_Switch = 2131558677;
+			
+			// aapt resource value: 0x7F0D0116
+			public static int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131558678;
+			
+			// aapt resource value: 0x7F0D0117
+			public static int TextAppearance_Compat_Notification = 2131558679;
+			
+			// aapt resource value: 0x7F0D0118
+			public static int TextAppearance_Compat_Notification_Info = 2131558680;
+			
+			// aapt resource value: 0x7F0D0119
+			public static int TextAppearance_Compat_Notification_Info_Media = 2131558681;
+			
+			// aapt resource value: 0x7F0D011A
+			public static int TextAppearance_Compat_Notification_Line2 = 2131558682;
+			
+			// aapt resource value: 0x7F0D011B
+			public static int TextAppearance_Compat_Notification_Line2_Media = 2131558683;
+			
+			// aapt resource value: 0x7F0D011C
+			public static int TextAppearance_Compat_Notification_Media = 2131558684;
+			
+			// aapt resource value: 0x7F0D011D
+			public static int TextAppearance_Compat_Notification_Time = 2131558685;
+			
+			// aapt resource value: 0x7F0D011E
+			public static int TextAppearance_Compat_Notification_Time_Media = 2131558686;
+			
+			// aapt resource value: 0x7F0D011F
+			public static int TextAppearance_Compat_Notification_Title = 2131558687;
+			
+			// aapt resource value: 0x7F0D0120
+			public static int TextAppearance_Compat_Notification_Title_Media = 2131558688;
+			
+			// aapt resource value: 0x7F0D0121
+			public static int TextAppearance_Design_CollapsingToolbar_Expanded = 2131558689;
+			
+			// aapt resource value: 0x7F0D0122
+			public static int TextAppearance_Design_Counter = 2131558690;
+			
+			// aapt resource value: 0x7F0D0123
+			public static int TextAppearance_Design_Counter_Overflow = 2131558691;
+			
+			// aapt resource value: 0x7F0D0124
+			public static int TextAppearance_Design_Error = 2131558692;
+			
+			// aapt resource value: 0x7F0D0125
+			public static int TextAppearance_Design_HelperText = 2131558693;
+			
+			// aapt resource value: 0x7F0D0126
+			public static int TextAppearance_Design_Hint = 2131558694;
+			
+			// aapt resource value: 0x7F0D0127
+			public static int TextAppearance_Design_Snackbar_Message = 2131558695;
+			
+			// aapt resource value: 0x7F0D0128
+			public static int TextAppearance_Design_Tab = 2131558696;
+			
+			// aapt resource value: 0x7F0D0129
+			public static int TextAppearance_MaterialComponents_Body1 = 2131558697;
+			
+			// aapt resource value: 0x7F0D012A
+			public static int TextAppearance_MaterialComponents_Body2 = 2131558698;
+			
+			// aapt resource value: 0x7F0D012B
+			public static int TextAppearance_MaterialComponents_Button = 2131558699;
+			
+			// aapt resource value: 0x7F0D012C
+			public static int TextAppearance_MaterialComponents_Caption = 2131558700;
+			
+			// aapt resource value: 0x7F0D012D
+			public static int TextAppearance_MaterialComponents_Chip = 2131558701;
+			
+			// aapt resource value: 0x7F0D012E
+			public static int TextAppearance_MaterialComponents_Headline1 = 2131558702;
+			
+			// aapt resource value: 0x7F0D012F
+			public static int TextAppearance_MaterialComponents_Headline2 = 2131558703;
+			
+			// aapt resource value: 0x7F0D0130
+			public static int TextAppearance_MaterialComponents_Headline3 = 2131558704;
+			
+			// aapt resource value: 0x7F0D0131
+			public static int TextAppearance_MaterialComponents_Headline4 = 2131558705;
+			
+			// aapt resource value: 0x7F0D0132
+			public static int TextAppearance_MaterialComponents_Headline5 = 2131558706;
+			
+			// aapt resource value: 0x7F0D0133
+			public static int TextAppearance_MaterialComponents_Headline6 = 2131558707;
+			
+			// aapt resource value: 0x7F0D0134
+			public static int TextAppearance_MaterialComponents_Overline = 2131558708;
+			
+			// aapt resource value: 0x7F0D0135
+			public static int TextAppearance_MaterialComponents_Subtitle1 = 2131558709;
+			
+			// aapt resource value: 0x7F0D0136
+			public static int TextAppearance_MaterialComponents_Subtitle2 = 2131558710;
+			
+			// aapt resource value: 0x7F0D0137
+			public static int TextAppearance_MaterialComponents_Tab = 2131558711;
+			
+			// aapt resource value: 0x7F0D0138
+			public static int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131558712;
+			
+			// aapt resource value: 0x7F0D0139
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131558713;
+			
+			// aapt resource value: 0x7F0D013A
+			public static int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131558714;
+			
+			// aapt resource value: 0x7F0D016B
+			public static int ThemeOverlay_AppCompat = 2131558763;
+			
+			// aapt resource value: 0x7F0D016C
+			public static int ThemeOverlay_AppCompat_ActionBar = 2131558764;
+			
+			// aapt resource value: 0x7F0D016D
+			public static int ThemeOverlay_AppCompat_Dark = 2131558765;
+			
+			// aapt resource value: 0x7F0D016E
+			public static int ThemeOverlay_AppCompat_Dark_ActionBar = 2131558766;
+			
+			// aapt resource value: 0x7F0D016F
+			public static int ThemeOverlay_AppCompat_Dialog = 2131558767;
+			
+			// aapt resource value: 0x7F0D0170
+			public static int ThemeOverlay_AppCompat_Dialog_Alert = 2131558768;
+			
+			// aapt resource value: 0x7F0D0171
+			public static int ThemeOverlay_AppCompat_Light = 2131558769;
+			
+			// aapt resource value: 0x7F0D0172
+			public static int ThemeOverlay_MaterialComponents = 2131558770;
+			
+			// aapt resource value: 0x7F0D0173
+			public static int ThemeOverlay_MaterialComponents_ActionBar = 2131558771;
+			
+			// aapt resource value: 0x7F0D0174
+			public static int ThemeOverlay_MaterialComponents_Dark = 2131558772;
+			
+			// aapt resource value: 0x7F0D0175
+			public static int ThemeOverlay_MaterialComponents_Dark_ActionBar = 2131558773;
+			
+			// aapt resource value: 0x7F0D0176
+			public static int ThemeOverlay_MaterialComponents_Dialog = 2131558774;
+			
+			// aapt resource value: 0x7F0D0177
+			public static int ThemeOverlay_MaterialComponents_Dialog_Alert = 2131558775;
+			
+			// aapt resource value: 0x7F0D0178
+			public static int ThemeOverlay_MaterialComponents_Light = 2131558776;
+			
+			// aapt resource value: 0x7F0D0179
+			public static int ThemeOverlay_MaterialComponents_TextInputEditText = 2131558777;
+			
+			// aapt resource value: 0x7F0D017A
+			public static int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox = 2131558778;
+			
+			// aapt resource value: 0x7F0D017B
+			public static int ThemeOverlay_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131558779;
+			
+			// aapt resource value: 0x7F0D017C
+			public static int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox = 2131558780;
+			
+			// aapt resource value: 0x7F0D017D
+			public static int ThemeOverlay_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131558781;
+			
+			// aapt resource value: 0x7F0D013B
+			public static int Theme_AppCompat = 2131558715;
+			
+			// aapt resource value: 0x7F0D013C
+			public static int Theme_AppCompat_CompactMenu = 2131558716;
+			
+			// aapt resource value: 0x7F0D013D
+			public static int Theme_AppCompat_DayNight = 2131558717;
+			
+			// aapt resource value: 0x7F0D013E
+			public static int Theme_AppCompat_DayNight_DarkActionBar = 2131558718;
+			
+			// aapt resource value: 0x7F0D013F
+			public static int Theme_AppCompat_DayNight_Dialog = 2131558719;
+			
+			// aapt resource value: 0x7F0D0142
+			public static int Theme_AppCompat_DayNight_DialogWhenLarge = 2131558722;
+			
+			// aapt resource value: 0x7F0D0140
+			public static int Theme_AppCompat_DayNight_Dialog_Alert = 2131558720;
+			
+			// aapt resource value: 0x7F0D0141
+			public static int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131558721;
+			
+			// aapt resource value: 0x7F0D0143
+			public static int Theme_AppCompat_DayNight_NoActionBar = 2131558723;
+			
+			// aapt resource value: 0x7F0D0144
+			public static int Theme_AppCompat_Dialog = 2131558724;
+			
+			// aapt resource value: 0x7F0D0147
+			public static int Theme_AppCompat_DialogWhenLarge = 2131558727;
+			
+			// aapt resource value: 0x7F0D0145
+			public static int Theme_AppCompat_Dialog_Alert = 2131558725;
+			
+			// aapt resource value: 0x7F0D0146
+			public static int Theme_AppCompat_Dialog_MinWidth = 2131558726;
+			
+			// aapt resource value: 0x7F0D0148
+			public static int Theme_AppCompat_Light = 2131558728;
+			
+			// aapt resource value: 0x7F0D0149
+			public static int Theme_AppCompat_Light_DarkActionBar = 2131558729;
+			
+			// aapt resource value: 0x7F0D014A
+			public static int Theme_AppCompat_Light_Dialog = 2131558730;
+			
+			// aapt resource value: 0x7F0D014D
+			public static int Theme_AppCompat_Light_DialogWhenLarge = 2131558733;
+			
+			// aapt resource value: 0x7F0D014B
+			public static int Theme_AppCompat_Light_Dialog_Alert = 2131558731;
+			
+			// aapt resource value: 0x7F0D014C
+			public static int Theme_AppCompat_Light_Dialog_MinWidth = 2131558732;
+			
+			// aapt resource value: 0x7F0D014E
+			public static int Theme_AppCompat_Light_NoActionBar = 2131558734;
+			
+			// aapt resource value: 0x7F0D014F
+			public static int Theme_AppCompat_NoActionBar = 2131558735;
+			
+			// aapt resource value: 0x7F0D0150
+			public static int Theme_Design = 2131558736;
+			
+			// aapt resource value: 0x7F0D0151
+			public static int Theme_Design_BottomSheetDialog = 2131558737;
+			
+			// aapt resource value: 0x7F0D0152
+			public static int Theme_Design_Light = 2131558738;
+			
+			// aapt resource value: 0x7F0D0153
+			public static int Theme_Design_Light_BottomSheetDialog = 2131558739;
+			
+			// aapt resource value: 0x7F0D0154
+			public static int Theme_Design_Light_NoActionBar = 2131558740;
+			
+			// aapt resource value: 0x7F0D0155
+			public static int Theme_Design_NoActionBar = 2131558741;
+			
+			// aapt resource value: 0x7F0D0156
+			public static int Theme_MaterialComponents = 2131558742;
+			
+			// aapt resource value: 0x7F0D0157
+			public static int Theme_MaterialComponents_BottomSheetDialog = 2131558743;
+			
+			// aapt resource value: 0x7F0D0158
+			public static int Theme_MaterialComponents_Bridge = 2131558744;
+			
+			// aapt resource value: 0x7F0D0159
+			public static int Theme_MaterialComponents_CompactMenu = 2131558745;
+			
+			// aapt resource value: 0x7F0D015A
+			public static int Theme_MaterialComponents_Dialog = 2131558746;
+			
+			// aapt resource value: 0x7F0D015D
+			public static int Theme_MaterialComponents_DialogWhenLarge = 2131558749;
+			
+			// aapt resource value: 0x7F0D015B
+			public static int Theme_MaterialComponents_Dialog_Alert = 2131558747;
+			
+			// aapt resource value: 0x7F0D015C
+			public static int Theme_MaterialComponents_Dialog_MinWidth = 2131558748;
+			
+			// aapt resource value: 0x7F0D015E
+			public static int Theme_MaterialComponents_Light = 2131558750;
+			
+			// aapt resource value: 0x7F0D015F
+			public static int Theme_MaterialComponents_Light_BottomSheetDialog = 2131558751;
+			
+			// aapt resource value: 0x7F0D0160
+			public static int Theme_MaterialComponents_Light_Bridge = 2131558752;
+			
+			// aapt resource value: 0x7F0D0161
+			public static int Theme_MaterialComponents_Light_DarkActionBar = 2131558753;
+			
+			// aapt resource value: 0x7F0D0162
+			public static int Theme_MaterialComponents_Light_DarkActionBar_Bridge = 2131558754;
+			
+			// aapt resource value: 0x7F0D0163
+			public static int Theme_MaterialComponents_Light_Dialog = 2131558755;
+			
+			// aapt resource value: 0x7F0D0166
+			public static int Theme_MaterialComponents_Light_DialogWhenLarge = 2131558758;
+			
+			// aapt resource value: 0x7F0D0164
+			public static int Theme_MaterialComponents_Light_Dialog_Alert = 2131558756;
+			
+			// aapt resource value: 0x7F0D0165
+			public static int Theme_MaterialComponents_Light_Dialog_MinWidth = 2131558757;
+			
+			// aapt resource value: 0x7F0D0167
+			public static int Theme_MaterialComponents_Light_NoActionBar = 2131558759;
+			
+			// aapt resource value: 0x7F0D0168
+			public static int Theme_MaterialComponents_Light_NoActionBar_Bridge = 2131558760;
+			
+			// aapt resource value: 0x7F0D0169
+			public static int Theme_MaterialComponents_NoActionBar = 2131558761;
+			
+			// aapt resource value: 0x7F0D016A
+			public static int Theme_MaterialComponents_NoActionBar_Bridge = 2131558762;
+			
+			// aapt resource value: 0x7F0D017E
+			public static int Widget_AppCompat_ActionBar = 2131558782;
+			
+			// aapt resource value: 0x7F0D017F
+			public static int Widget_AppCompat_ActionBar_Solid = 2131558783;
+			
+			// aapt resource value: 0x7F0D0180
+			public static int Widget_AppCompat_ActionBar_TabBar = 2131558784;
+			
+			// aapt resource value: 0x7F0D0181
+			public static int Widget_AppCompat_ActionBar_TabText = 2131558785;
+			
+			// aapt resource value: 0x7F0D0182
+			public static int Widget_AppCompat_ActionBar_TabView = 2131558786;
+			
+			// aapt resource value: 0x7F0D0183
+			public static int Widget_AppCompat_ActionButton = 2131558787;
+			
+			// aapt resource value: 0x7F0D0184
+			public static int Widget_AppCompat_ActionButton_CloseMode = 2131558788;
+			
+			// aapt resource value: 0x7F0D0185
+			public static int Widget_AppCompat_ActionButton_Overflow = 2131558789;
+			
+			// aapt resource value: 0x7F0D0186
+			public static int Widget_AppCompat_ActionMode = 2131558790;
+			
+			// aapt resource value: 0x7F0D0187
+			public static int Widget_AppCompat_ActivityChooserView = 2131558791;
+			
+			// aapt resource value: 0x7F0D0188
+			public static int Widget_AppCompat_AutoCompleteTextView = 2131558792;
+			
+			// aapt resource value: 0x7F0D0189
+			public static int Widget_AppCompat_Button = 2131558793;
+			
+			// aapt resource value: 0x7F0D018F
+			public static int Widget_AppCompat_ButtonBar = 2131558799;
+			
+			// aapt resource value: 0x7F0D0190
+			public static int Widget_AppCompat_ButtonBar_AlertDialog = 2131558800;
+			
+			// aapt resource value: 0x7F0D018A
+			public static int Widget_AppCompat_Button_Borderless = 2131558794;
+			
+			// aapt resource value: 0x7F0D018B
+			public static int Widget_AppCompat_Button_Borderless_Colored = 2131558795;
+			
+			// aapt resource value: 0x7F0D018C
+			public static int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131558796;
+			
+			// aapt resource value: 0x7F0D018D
+			public static int Widget_AppCompat_Button_Colored = 2131558797;
+			
+			// aapt resource value: 0x7F0D018E
+			public static int Widget_AppCompat_Button_Small = 2131558798;
+			
+			// aapt resource value: 0x7F0D0191
+			public static int Widget_AppCompat_CompoundButton_CheckBox = 2131558801;
+			
+			// aapt resource value: 0x7F0D0192
+			public static int Widget_AppCompat_CompoundButton_RadioButton = 2131558802;
+			
+			// aapt resource value: 0x7F0D0193
+			public static int Widget_AppCompat_CompoundButton_Switch = 2131558803;
+			
+			// aapt resource value: 0x7F0D0194
+			public static int Widget_AppCompat_DrawerArrowToggle = 2131558804;
+			
+			// aapt resource value: 0x7F0D0195
+			public static int Widget_AppCompat_DropDownItem_Spinner = 2131558805;
+			
+			// aapt resource value: 0x7F0D0196
+			public static int Widget_AppCompat_EditText = 2131558806;
+			
+			// aapt resource value: 0x7F0D0197
+			public static int Widget_AppCompat_ImageButton = 2131558807;
+			
+			// aapt resource value: 0x7F0D0198
+			public static int Widget_AppCompat_Light_ActionBar = 2131558808;
+			
+			// aapt resource value: 0x7F0D0199
+			public static int Widget_AppCompat_Light_ActionBar_Solid = 2131558809;
+			
+			// aapt resource value: 0x7F0D019A
+			public static int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131558810;
+			
+			// aapt resource value: 0x7F0D019B
+			public static int Widget_AppCompat_Light_ActionBar_TabBar = 2131558811;
+			
+			// aapt resource value: 0x7F0D019C
+			public static int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131558812;
+			
+			// aapt resource value: 0x7F0D019D
+			public static int Widget_AppCompat_Light_ActionBar_TabText = 2131558813;
+			
+			// aapt resource value: 0x7F0D019E
+			public static int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131558814;
+			
+			// aapt resource value: 0x7F0D019F
+			public static int Widget_AppCompat_Light_ActionBar_TabView = 2131558815;
+			
+			// aapt resource value: 0x7F0D01A0
+			public static int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131558816;
+			
+			// aapt resource value: 0x7F0D01A1
+			public static int Widget_AppCompat_Light_ActionButton = 2131558817;
+			
+			// aapt resource value: 0x7F0D01A2
+			public static int Widget_AppCompat_Light_ActionButton_CloseMode = 2131558818;
+			
+			// aapt resource value: 0x7F0D01A3
+			public static int Widget_AppCompat_Light_ActionButton_Overflow = 2131558819;
+			
+			// aapt resource value: 0x7F0D01A4
+			public static int Widget_AppCompat_Light_ActionMode_Inverse = 2131558820;
+			
+			// aapt resource value: 0x7F0D01A5
+			public static int Widget_AppCompat_Light_ActivityChooserView = 2131558821;
+			
+			// aapt resource value: 0x7F0D01A6
+			public static int Widget_AppCompat_Light_AutoCompleteTextView = 2131558822;
+			
+			// aapt resource value: 0x7F0D01A7
+			public static int Widget_AppCompat_Light_DropDownItem_Spinner = 2131558823;
+			
+			// aapt resource value: 0x7F0D01A8
+			public static int Widget_AppCompat_Light_ListPopupWindow = 2131558824;
+			
+			// aapt resource value: 0x7F0D01A9
+			public static int Widget_AppCompat_Light_ListView_DropDown = 2131558825;
+			
+			// aapt resource value: 0x7F0D01AA
+			public static int Widget_AppCompat_Light_PopupMenu = 2131558826;
+			
+			// aapt resource value: 0x7F0D01AB
+			public static int Widget_AppCompat_Light_PopupMenu_Overflow = 2131558827;
+			
+			// aapt resource value: 0x7F0D01AC
+			public static int Widget_AppCompat_Light_SearchView = 2131558828;
+			
+			// aapt resource value: 0x7F0D01AD
+			public static int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131558829;
+			
+			// aapt resource value: 0x7F0D01AE
+			public static int Widget_AppCompat_ListMenuView = 2131558830;
+			
+			// aapt resource value: 0x7F0D01AF
+			public static int Widget_AppCompat_ListPopupWindow = 2131558831;
+			
+			// aapt resource value: 0x7F0D01B0
+			public static int Widget_AppCompat_ListView = 2131558832;
+			
+			// aapt resource value: 0x7F0D01B1
+			public static int Widget_AppCompat_ListView_DropDown = 2131558833;
+			
+			// aapt resource value: 0x7F0D01B2
+			public static int Widget_AppCompat_ListView_Menu = 2131558834;
+			
+			// aapt resource value: 0x7F0D01B3
+			public static int Widget_AppCompat_PopupMenu = 2131558835;
+			
+			// aapt resource value: 0x7F0D01B4
+			public static int Widget_AppCompat_PopupMenu_Overflow = 2131558836;
+			
+			// aapt resource value: 0x7F0D01B5
+			public static int Widget_AppCompat_PopupWindow = 2131558837;
+			
+			// aapt resource value: 0x7F0D01B6
+			public static int Widget_AppCompat_ProgressBar = 2131558838;
+			
+			// aapt resource value: 0x7F0D01B7
+			public static int Widget_AppCompat_ProgressBar_Horizontal = 2131558839;
+			
+			// aapt resource value: 0x7F0D01B8
+			public static int Widget_AppCompat_RatingBar = 2131558840;
+			
+			// aapt resource value: 0x7F0D01B9
+			public static int Widget_AppCompat_RatingBar_Indicator = 2131558841;
+			
+			// aapt resource value: 0x7F0D01BA
+			public static int Widget_AppCompat_RatingBar_Small = 2131558842;
+			
+			// aapt resource value: 0x7F0D01BB
+			public static int Widget_AppCompat_SearchView = 2131558843;
+			
+			// aapt resource value: 0x7F0D01BC
+			public static int Widget_AppCompat_SearchView_ActionBar = 2131558844;
+			
+			// aapt resource value: 0x7F0D01BD
+			public static int Widget_AppCompat_SeekBar = 2131558845;
+			
+			// aapt resource value: 0x7F0D01BE
+			public static int Widget_AppCompat_SeekBar_Discrete = 2131558846;
+			
+			// aapt resource value: 0x7F0D01BF
+			public static int Widget_AppCompat_Spinner = 2131558847;
+			
+			// aapt resource value: 0x7F0D01C0
+			public static int Widget_AppCompat_Spinner_DropDown = 2131558848;
+			
+			// aapt resource value: 0x7F0D01C1
+			public static int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131558849;
+			
+			// aapt resource value: 0x7F0D01C2
+			public static int Widget_AppCompat_Spinner_Underlined = 2131558850;
+			
+			// aapt resource value: 0x7F0D01C3
+			public static int Widget_AppCompat_TextView_SpinnerItem = 2131558851;
+			
+			// aapt resource value: 0x7F0D01C4
+			public static int Widget_AppCompat_Toolbar = 2131558852;
+			
+			// aapt resource value: 0x7F0D01C5
+			public static int Widget_AppCompat_Toolbar_Button_Navigation = 2131558853;
+			
+			// aapt resource value: 0x7F0D01C6
+			public static int Widget_Compat_NotificationActionContainer = 2131558854;
+			
+			// aapt resource value: 0x7F0D01C7
+			public static int Widget_Compat_NotificationActionText = 2131558855;
+			
+			// aapt resource value: 0x7F0D01C8
+			public static int Widget_Design_AppBarLayout = 2131558856;
+			
+			// aapt resource value: 0x7F0D01C9
+			public static int Widget_Design_BottomNavigationView = 2131558857;
+			
+			// aapt resource value: 0x7F0D01CA
+			public static int Widget_Design_BottomSheet_Modal = 2131558858;
+			
+			// aapt resource value: 0x7F0D01CB
+			public static int Widget_Design_CollapsingToolbar = 2131558859;
+			
+			// aapt resource value: 0x7F0D01CC
+			public static int Widget_Design_FloatingActionButton = 2131558860;
+			
+			// aapt resource value: 0x7F0D01CD
+			public static int Widget_Design_NavigationView = 2131558861;
+			
+			// aapt resource value: 0x7F0D01CE
+			public static int Widget_Design_ScrimInsetsFrameLayout = 2131558862;
+			
+			// aapt resource value: 0x7F0D01CF
+			public static int Widget_Design_Snackbar = 2131558863;
+			
+			// aapt resource value: 0x7F0D01D0
+			public static int Widget_Design_TabLayout = 2131558864;
+			
+			// aapt resource value: 0x7F0D01D1
+			public static int Widget_Design_TextInputLayout = 2131558865;
+			
+			// aapt resource value: 0x7F0D01D2
+			public static int Widget_MaterialComponents_BottomAppBar = 2131558866;
+			
+			// aapt resource value: 0x7F0D01D3
+			public static int Widget_MaterialComponents_BottomAppBar_Colored = 2131558867;
+			
+			// aapt resource value: 0x7F0D01D4
+			public static int Widget_MaterialComponents_BottomNavigationView = 2131558868;
+			
+			// aapt resource value: 0x7F0D01D5
+			public static int Widget_MaterialComponents_BottomNavigationView_Colored = 2131558869;
+			
+			// aapt resource value: 0x7F0D01D6
+			public static int Widget_MaterialComponents_BottomSheet_Modal = 2131558870;
+			
+			// aapt resource value: 0x7F0D01D7
+			public static int Widget_MaterialComponents_Button = 2131558871;
+			
+			// aapt resource value: 0x7F0D01D8
+			public static int Widget_MaterialComponents_Button_Icon = 2131558872;
+			
+			// aapt resource value: 0x7F0D01D9
+			public static int Widget_MaterialComponents_Button_OutlinedButton = 2131558873;
+			
+			// aapt resource value: 0x7F0D01DA
+			public static int Widget_MaterialComponents_Button_OutlinedButton_Icon = 2131558874;
+			
+			// aapt resource value: 0x7F0D01DB
+			public static int Widget_MaterialComponents_Button_TextButton = 2131558875;
+			
+			// aapt resource value: 0x7F0D01DC
+			public static int Widget_MaterialComponents_Button_TextButton_Dialog = 2131558876;
+			
+			// aapt resource value: 0x7F0D01DD
+			public static int Widget_MaterialComponents_Button_TextButton_Dialog_Icon = 2131558877;
+			
+			// aapt resource value: 0x7F0D01DE
+			public static int Widget_MaterialComponents_Button_TextButton_Icon = 2131558878;
+			
+			// aapt resource value: 0x7F0D01DF
+			public static int Widget_MaterialComponents_Button_UnelevatedButton = 2131558879;
+			
+			// aapt resource value: 0x7F0D01E0
+			public static int Widget_MaterialComponents_Button_UnelevatedButton_Icon = 2131558880;
+			
+			// aapt resource value: 0x7F0D01E1
+			public static int Widget_MaterialComponents_CardView = 2131558881;
+			
+			// aapt resource value: 0x7F0D01E6
+			public static int Widget_MaterialComponents_ChipGroup = 2131558886;
+			
+			// aapt resource value: 0x7F0D01E2
+			public static int Widget_MaterialComponents_Chip_Action = 2131558882;
+			
+			// aapt resource value: 0x7F0D01E3
+			public static int Widget_MaterialComponents_Chip_Choice = 2131558883;
+			
+			// aapt resource value: 0x7F0D01E4
+			public static int Widget_MaterialComponents_Chip_Entry = 2131558884;
+			
+			// aapt resource value: 0x7F0D01E5
+			public static int Widget_MaterialComponents_Chip_Filter = 2131558885;
+			
+			// aapt resource value: 0x7F0D01E7
+			public static int Widget_MaterialComponents_FloatingActionButton = 2131558887;
+			
+			// aapt resource value: 0x7F0D01E8
+			public static int Widget_MaterialComponents_NavigationView = 2131558888;
+			
+			// aapt resource value: 0x7F0D01E9
+			public static int Widget_MaterialComponents_Snackbar = 2131558889;
+			
+			// aapt resource value: 0x7F0D01EA
+			public static int Widget_MaterialComponents_Snackbar_FullWidth = 2131558890;
+			
+			// aapt resource value: 0x7F0D01EB
+			public static int Widget_MaterialComponents_TabLayout = 2131558891;
+			
+			// aapt resource value: 0x7F0D01EC
+			public static int Widget_MaterialComponents_TabLayout_Colored = 2131558892;
+			
+			// aapt resource value: 0x7F0D01ED
+			public static int Widget_MaterialComponents_TextInputEditText_FilledBox = 2131558893;
+			
+			// aapt resource value: 0x7F0D01EE
+			public static int Widget_MaterialComponents_TextInputEditText_FilledBox_Dense = 2131558894;
+			
+			// aapt resource value: 0x7F0D01EF
+			public static int Widget_MaterialComponents_TextInputEditText_OutlinedBox = 2131558895;
+			
+			// aapt resource value: 0x7F0D01F0
+			public static int Widget_MaterialComponents_TextInputEditText_OutlinedBox_Dense = 2131558896;
+			
+			// aapt resource value: 0x7F0D01F1
+			public static int Widget_MaterialComponents_TextInputLayout_FilledBox = 2131558897;
+			
+			// aapt resource value: 0x7F0D01F2
+			public static int Widget_MaterialComponents_TextInputLayout_FilledBox_Dense = 2131558898;
+			
+			// aapt resource value: 0x7F0D01F3
+			public static int Widget_MaterialComponents_TextInputLayout_OutlinedBox = 2131558899;
+			
+			// aapt resource value: 0x7F0D01F4
+			public static int Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense = 2131558900;
+			
+			// aapt resource value: 0x7F0D01F5
+			public static int Widget_MaterialComponents_Toolbar = 2131558901;
+			
+			// aapt resource value: 0x7F0D01F6
+			public static int Widget_Support_CoordinatorLayout = 2131558902;
 			
 			static Style()
 			{
@@ -1072,8 +5680,450 @@ namespace AirshipBindings.NETStandard
 		public partial class Styleable
 		{
 			
-			// aapt resource value: { 0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030009,0x7F03000A }
-			public static int[] MessageCenter = new int[] {
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F030033,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F0300A4,0x7F0300A9,0x7F0300AA,0x7F0300B5,0x7F0300DF,0x7F0300E4,0x7F0300E9,0x7F0300EA,0x7F0300EC,0x7F0300F6,0x7F030100,0x7F030123,0x7F03012F,0x7F030140,0x7F030144,0x7F030145,0x7F030173,0x7F030176,0x7F0301BB,0x7F0301C5 }
+			public static int[] ActionBar = new int[] {
+					2130903089,
+					2130903090,
+					2130903091,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
+					2130903204,
+					2130903209,
+					2130903210,
+					2130903221,
+					2130903263,
+					2130903268,
+					2130903273,
+					2130903274,
+					2130903276,
+					2130903286,
+					2130903296,
+					2130903331,
+					2130903343,
+					2130903360,
+					2130903364,
+					2130903365,
+					2130903411,
+					2130903414,
+					2130903483,
+					2130903493};
+			
+			// aapt resource value: { 0x10100B3 }
+			public static int[] ActionBarLayout = new int[] {
+					16842931};
+			
+			// aapt resource value: 0
+			public static int ActionBarLayout_android_layout_gravity = 0;
+			
+			// aapt resource value: 0
+			public static int ActionBar_background = 0;
+			
+			// aapt resource value: 1
+			public static int ActionBar_backgroundSplit = 1;
+			
+			// aapt resource value: 2
+			public static int ActionBar_backgroundStacked = 2;
+			
+			// aapt resource value: 3
+			public static int ActionBar_contentInsetEnd = 3;
+			
+			// aapt resource value: 4
+			public static int ActionBar_contentInsetEndWithActions = 4;
+			
+			// aapt resource value: 5
+			public static int ActionBar_contentInsetLeft = 5;
+			
+			// aapt resource value: 6
+			public static int ActionBar_contentInsetRight = 6;
+			
+			// aapt resource value: 7
+			public static int ActionBar_contentInsetStart = 7;
+			
+			// aapt resource value: 8
+			public static int ActionBar_contentInsetStartWithNavigation = 8;
+			
+			// aapt resource value: 9
+			public static int ActionBar_customNavigationLayout = 9;
+			
+			// aapt resource value: 10
+			public static int ActionBar_displayOptions = 10;
+			
+			// aapt resource value: 11
+			public static int ActionBar_divider = 11;
+			
+			// aapt resource value: 12
+			public static int ActionBar_elevation = 12;
+			
+			// aapt resource value: 13
+			public static int ActionBar_height = 13;
+			
+			// aapt resource value: 14
+			public static int ActionBar_hideOnContentScroll = 14;
+			
+			// aapt resource value: 15
+			public static int ActionBar_homeAsUpIndicator = 15;
+			
+			// aapt resource value: 16
+			public static int ActionBar_homeLayout = 16;
+			
+			// aapt resource value: 17
+			public static int ActionBar_icon = 17;
+			
+			// aapt resource value: 18
+			public static int ActionBar_indeterminateProgressStyle = 18;
+			
+			// aapt resource value: 19
+			public static int ActionBar_itemPadding = 19;
+			
+			// aapt resource value: 20
+			public static int ActionBar_logo = 20;
+			
+			// aapt resource value: 21
+			public static int ActionBar_navigationMode = 21;
+			
+			// aapt resource value: 22
+			public static int ActionBar_popupTheme = 22;
+			
+			// aapt resource value: 23
+			public static int ActionBar_progressBarPadding = 23;
+			
+			// aapt resource value: 24
+			public static int ActionBar_progressBarStyle = 24;
+			
+			// aapt resource value: 25
+			public static int ActionBar_subtitle = 25;
+			
+			// aapt resource value: 26
+			public static int ActionBar_subtitleTextStyle = 26;
+			
+			// aapt resource value: 27
+			public static int ActionBar_title = 27;
+			
+			// aapt resource value: 28
+			public static int ActionBar_titleTextStyle = 28;
+			
+			// aapt resource value: { 0x101013F }
+			public static int[] ActionMenuItemView = new int[] {
+					16843071};
+			
+			// aapt resource value: 0
+			public static int ActionMenuItemView_android_minWidth = 0;
+			
+			// aapt resource value: { 0xFFFFFFFF }
+			public static int[] ActionMenuView = new int[] {
+					-1};
+			
+			// aapt resource value: { 0x7F030031,0x7F030032,0x7F03007E,0x7F0300DF,0x7F030176,0x7F0301C5 }
+			public static int[] ActionMode = new int[] {
+					2130903089,
+					2130903090,
+					2130903166,
+					2130903263,
+					2130903414,
+					2130903493};
+			
+			// aapt resource value: 0
+			public static int ActionMode_background = 0;
+			
+			// aapt resource value: 1
+			public static int ActionMode_backgroundSplit = 1;
+			
+			// aapt resource value: 2
+			public static int ActionMode_closeItemLayout = 2;
+			
+			// aapt resource value: 3
+			public static int ActionMode_height = 3;
+			
+			// aapt resource value: 4
+			public static int ActionMode_subtitleTextStyle = 4;
+			
+			// aapt resource value: 5
+			public static int ActionMode_titleTextStyle = 5;
+			
+			// aapt resource value: { 0x7F0300BA,0x7F0300F7 }
+			public static int[] ActivityChooserView = new int[] {
+					2130903226,
+					2130903287};
+			
+			// aapt resource value: 0
+			public static int ActivityChooserView_expandActivityOverflowButtonDrawable = 0;
+			
+			// aapt resource value: 1
+			public static int ActivityChooserView_initialActivityCount = 1;
+			
+			// aapt resource value: { 0x10100F2,0x7F030052,0x7F030053,0x7F03011A,0x7F03011B,0x7F03012C,0x7F03015B,0x7F03015C }
+			public static int[] AlertDialog = new int[] {
+					16842994,
+					2130903122,
+					2130903123,
+					2130903322,
+					2130903323,
+					2130903340,
+					2130903387,
+					2130903388};
+			
+			// aapt resource value: 0
+			public static int AlertDialog_android_layout = 0;
+			
+			// aapt resource value: 1
+			public static int AlertDialog_buttonIconDimen = 1;
+			
+			// aapt resource value: 2
+			public static int AlertDialog_buttonPanelSideLayout = 2;
+			
+			// aapt resource value: 3
+			public static int AlertDialog_listItemLayout = 3;
+			
+			// aapt resource value: 4
+			public static int AlertDialog_listLayout = 4;
+			
+			// aapt resource value: 5
+			public static int AlertDialog_multiChoiceItemLayout = 5;
+			
+			// aapt resource value: 6
+			public static int AlertDialog_showTitle = 6;
+			
+			// aapt resource value: 7
+			public static int AlertDialog_singleChoiceItemLayout = 7;
+			
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] AnimatedStateListDrawableCompat = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: 3
+			public static int AnimatedStateListDrawableCompat_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public static int AnimatedStateListDrawableCompat_android_dither = 0;
+			
+			// aapt resource value: 4
+			public static int AnimatedStateListDrawableCompat_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public static int AnimatedStateListDrawableCompat_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public static int AnimatedStateListDrawableCompat_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public static int AnimatedStateListDrawableCompat_android_visible = 1;
+			
+			// aapt resource value: { 0x10100D0,0x1010199 }
+			public static int[] AnimatedStateListDrawableItem = new int[] {
+					16842960,
+					16843161};
+			
+			// aapt resource value: 1
+			public static int AnimatedStateListDrawableItem_android_drawable = 1;
+			
+			// aapt resource value: 0
+			public static int AnimatedStateListDrawableItem_android_id = 0;
+			
+			// aapt resource value: { 0x1010199,0x1010449,0x101044A,0x101044B }
+			public static int[] AnimatedStateListDrawableTransition = new int[] {
+					16843161,
+					16843849,
+					16843850,
+					16843851};
+			
+			// aapt resource value: 0
+			public static int AnimatedStateListDrawableTransition_android_drawable = 0;
+			
+			// aapt resource value: 2
+			public static int AnimatedStateListDrawableTransition_android_fromId = 2;
+			
+			// aapt resource value: 3
+			public static int AnimatedStateListDrawableTransition_android_reversible = 3;
+			
+			// aapt resource value: 1
+			public static int AnimatedStateListDrawableTransition_android_toId = 1;
+			
+			// aapt resource value: { 0x10100D4,0x101048F,0x1010540,0x7F0300B5,0x7F0300BB,0x7F030115 }
+			public static int[] AppBarLayout = new int[] {
+					16842964,
+					16843919,
+					16844096,
+					2130903221,
+					2130903227,
+					2130903317};
+			
+			// aapt resource value: { 0x7F030169,0x7F03016A,0x7F03016B,0x7F03016C }
+			public static int[] AppBarLayoutStates = new int[] {
+					2130903401,
+					2130903402,
+					2130903403,
+					2130903404};
+			
+			// aapt resource value: 0
+			public static int AppBarLayoutStates_state_collapsed = 0;
+			
+			// aapt resource value: 1
+			public static int AppBarLayoutStates_state_collapsible = 1;
+			
+			// aapt resource value: 2
+			public static int AppBarLayoutStates_state_liftable = 2;
+			
+			// aapt resource value: 3
+			public static int AppBarLayoutStates_state_lifted = 3;
+			
+			// aapt resource value: 0
+			public static int AppBarLayout_android_background = 0;
+			
+			// aapt resource value: 2
+			public static int AppBarLayout_android_keyboardNavigationCluster = 2;
+			
+			// aapt resource value: 1
+			public static int AppBarLayout_android_touchscreenBlocksFocus = 1;
+			
+			// aapt resource value: 3
+			public static int AppBarLayout_elevation = 3;
+			
+			// aapt resource value: 4
+			public static int AppBarLayout_expanded = 4;
+			
+			// aapt resource value: { 0x7F030113,0x7F030114 }
+			public static int[] AppBarLayout_Layout = new int[] {
+					2130903315,
+					2130903316};
+			
+			// aapt resource value: 0
+			public static int AppBarLayout_Layout_layout_scrollFlags = 0;
+			
+			// aapt resource value: 1
+			public static int AppBarLayout_Layout_layout_scrollInterpolator = 1;
+			
+			// aapt resource value: 5
+			public static int AppBarLayout_liftOnScroll = 5;
+			
+			// aapt resource value: { 0x1010119,0x7F030166,0x7F0301B9,0x7F0301BA }
+			public static int[] AppCompatImageView = new int[] {
+					16843033,
+					2130903398,
+					2130903481,
+					2130903482};
+			
+			// aapt resource value: 0
+			public static int AppCompatImageView_android_src = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatImageView_srcCompat = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatImageView_tint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatImageView_tintMode = 3;
+			
+			// aapt resource value: { 0x1010142,0x7F0301B6,0x7F0301B7,0x7F0301B8 }
+			public static int[] AppCompatSeekBar = new int[] {
+					16843074,
+					2130903478,
+					2130903479,
+					2130903480};
+			
+			// aapt resource value: 0
+			public static int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			// aapt resource value: { 0x1010034,0x101016D,0x101016E,0x101016F,0x1010170,0x1010392,0x1010393 }
+			public static int[] AppCompatTextHelper = new int[] {
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public static int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public static int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public static int AppCompatTextHelper_android_textAppearance = 0;
+			
+			// aapt resource value: { 0x1010034,0x7F03002C,0x7F03002D,0x7F03002E,0x7F03002F,0x7F030030,0x7F0300CE,0x7F0300D1,0x7F030108,0x7F030116,0x7F030196 }
+			public static int[] AppCompatTextView = new int[] {
+					16842804,
+					2130903084,
+					2130903085,
+					2130903086,
+					2130903087,
+					2130903088,
+					2130903246,
+					2130903249,
+					2130903304,
+					2130903318,
+					2130903446};
+			
+			// aapt resource value: 0
+			public static int AppCompatTextView_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public static int AppCompatTextView_autoSizeMaxTextSize = 1;
+			
+			// aapt resource value: 2
+			public static int AppCompatTextView_autoSizeMinTextSize = 2;
+			
+			// aapt resource value: 3
+			public static int AppCompatTextView_autoSizePresetSizes = 3;
+			
+			// aapt resource value: 4
+			public static int AppCompatTextView_autoSizeStepGranularity = 4;
+			
+			// aapt resource value: 5
+			public static int AppCompatTextView_autoSizeTextType = 5;
+			
+			// aapt resource value: 6
+			public static int AppCompatTextView_firstBaselineToTopHeight = 6;
+			
+			// aapt resource value: 7
+			public static int AppCompatTextView_fontFamily = 7;
+			
+			// aapt resource value: 8
+			public static int AppCompatTextView_lastBaselineToBottomHeight = 8;
+			
+			// aapt resource value: 9
+			public static int AppCompatTextView_lineHeight = 9;
+			
+			// aapt resource value: 10
+			public static int AppCompatTextView_textAllCaps = 10;
+			
+			// aapt resource value: { 0x1010057,0x10100AE,0x7F030000,0x7F030001,0x7F030002,0x7F030003,0x7F030004,0x7F030005,0x7F030006,0x7F030007,0x7F030008,0x7F030009,0x7F03000A,0x7F03000B,0x7F03000C,0x7F03000E,0x7F03000F,0x7F030010,0x7F030011,0x7F030012,0x7F030013,0x7F030014,0x7F030015,0x7F030016,0x7F030017,0x7F030018,0x7F030019,0x7F03001A,0x7F03001B,0x7F03001C,0x7F03001D,0x7F03001E,0x7F030021,0x7F030022,0x7F030023,0x7F030024,0x7F030025,0x7F03002B,0x7F03003E,0x7F03004C,0x7F03004D,0x7F03004E,0x7F03004F,0x7F030050,0x7F030054,0x7F030055,0x7F03005F,0x7F030064,0x7F030084,0x7F030085,0x7F030086,0x7F030087,0x7F030088,0x7F030089,0x7F03008A,0x7F03008B,0x7F03008C,0x7F03008E,0x7F03009D,0x7F0300A6,0x7F0300A7,0x7F0300A8,0x7F0300AB,0x7F0300AD,0x7F0300B0,0x7F0300B1,0x7F0300B2,0x7F0300B3,0x7F0300B4,0x7F0300E9,0x7F0300F5,0x7F030118,0x7F030119,0x7F03011C,0x7F03011D,0x7F03011E,0x7F03011F,0x7F030120,0x7F030121,0x7F030122,0x7F030137,0x7F030138,0x7F030139,0x7F03013F,0x7F030141,0x7F030148,0x7F030149,0x7F03014A,0x7F03014B,0x7F030153,0x7F030154,0x7F030155,0x7F030156,0x7F030163,0x7F030164,0x7F03017A,0x7F0301A1,0x7F0301A2,0x7F0301A3,0x7F0301A4,0x7F0301A6,0x7F0301A7,0x7F0301A8,0x7F0301A9,0x7F0301AC,0x7F0301AD,0x7F0301C7,0x7F0301C8,0x7F0301C9,0x7F0301CA,0x7F0301D1,0x7F0301D3,0x7F0301D4,0x7F0301D5,0x7F0301D6,0x7F0301D7,0x7F0301D8,0x7F0301D9,0x7F0301DA,0x7F0301DB,0x7F0301DC }
+			public static int[] AppCompatTheme = new int[] {
+					16842839,
+					16842926,
 					2130903040,
 					2130903041,
 					2130903042,
@@ -1082,96 +6132,2485 @@ namespace AirshipBindings.NETStandard
 					2130903045,
 					2130903046,
 					2130903047,
+					2130903048,
 					2130903049,
-					2130903050};
-			
-			// aapt resource value: 0
-			public static int MessageCenter_messageCenterDividerColor = 0;
-			
-			// aapt resource value: 1
-			public static int MessageCenter_messageCenterEmptyMessageText = 1;
+					2130903050,
+					2130903051,
+					2130903052,
+					2130903054,
+					2130903055,
+					2130903056,
+					2130903057,
+					2130903058,
+					2130903059,
+					2130903060,
+					2130903061,
+					2130903062,
+					2130903063,
+					2130903064,
+					2130903065,
+					2130903066,
+					2130903067,
+					2130903068,
+					2130903069,
+					2130903070,
+					2130903073,
+					2130903074,
+					2130903075,
+					2130903076,
+					2130903077,
+					2130903083,
+					2130903102,
+					2130903116,
+					2130903117,
+					2130903118,
+					2130903119,
+					2130903120,
+					2130903124,
+					2130903125,
+					2130903135,
+					2130903140,
+					2130903172,
+					2130903173,
+					2130903174,
+					2130903175,
+					2130903176,
+					2130903177,
+					2130903178,
+					2130903179,
+					2130903180,
+					2130903182,
+					2130903197,
+					2130903206,
+					2130903207,
+					2130903208,
+					2130903211,
+					2130903213,
+					2130903216,
+					2130903217,
+					2130903218,
+					2130903219,
+					2130903220,
+					2130903273,
+					2130903285,
+					2130903320,
+					2130903321,
+					2130903324,
+					2130903325,
+					2130903326,
+					2130903327,
+					2130903328,
+					2130903329,
+					2130903330,
+					2130903351,
+					2130903352,
+					2130903353,
+					2130903359,
+					2130903361,
+					2130903368,
+					2130903369,
+					2130903370,
+					2130903371,
+					2130903379,
+					2130903380,
+					2130903381,
+					2130903382,
+					2130903395,
+					2130903396,
+					2130903418,
+					2130903457,
+					2130903458,
+					2130903459,
+					2130903460,
+					2130903462,
+					2130903463,
+					2130903464,
+					2130903465,
+					2130903468,
+					2130903469,
+					2130903495,
+					2130903496,
+					2130903497,
+					2130903498,
+					2130903505,
+					2130903507,
+					2130903508,
+					2130903509,
+					2130903510,
+					2130903511,
+					2130903512,
+					2130903513,
+					2130903514,
+					2130903515,
+					2130903516};
 			
 			// aapt resource value: 2
-			public static int MessageCenter_messageCenterEmptyMessageTextAppearance = 2;
+			public static int AppCompatTheme_actionBarDivider = 2;
 			
 			// aapt resource value: 3
-			public static int MessageCenter_messageCenterItemBackground = 3;
+			public static int AppCompatTheme_actionBarItemBackground = 3;
 			
 			// aapt resource value: 4
-			public static int MessageCenter_messageCenterItemDateTextAppearance = 4;
+			public static int AppCompatTheme_actionBarPopupTheme = 4;
 			
 			// aapt resource value: 5
-			public static int MessageCenter_messageCenterItemIconEnabled = 5;
+			public static int AppCompatTheme_actionBarSize = 5;
 			
 			// aapt resource value: 6
-			public static int MessageCenter_messageCenterItemIconPlaceholder = 6;
+			public static int AppCompatTheme_actionBarSplitStyle = 6;
 			
 			// aapt resource value: 7
-			public static int MessageCenter_messageCenterItemTitleTextAppearance = 7;
+			public static int AppCompatTheme_actionBarStyle = 7;
 			
 			// aapt resource value: 8
-			public static int MessageCenter_messageNotSelectedText = 8;
+			public static int AppCompatTheme_actionBarTabBarStyle = 8;
 			
 			// aapt resource value: 9
-			public static int MessageCenter_messageNotSelectedTextAppearance = 9;
+			public static int AppCompatTheme_actionBarTabStyle = 9;
 			
-			// aapt resource value: { 0x7F03000C }
-			public static int[] States = new int[] {
-					2130903052};
+			// aapt resource value: 10
+			public static int AppCompatTheme_actionBarTabTextStyle = 10;
 			
-			// aapt resource value: 0
-			public static int States_ua_state_highlighted = 0;
+			// aapt resource value: 11
+			public static int AppCompatTheme_actionBarTheme = 11;
 			
-			// aapt resource value: { 0x7F030008 }
-			public static int[] Theme = new int[] {
-					2130903048};
+			// aapt resource value: 12
+			public static int AppCompatTheme_actionBarWidgetTheme = 12;
 			
-			// aapt resource value: 0
-			public static int Theme_messageCenterStyle = 0;
+			// aapt resource value: 13
+			public static int AppCompatTheme_actionButtonStyle = 13;
 			
-			// aapt resource value: { 0x7F03000B }
-			public static int[] UAWebView = new int[] {
-					2130903051};
+			// aapt resource value: 14
+			public static int AppCompatTheme_actionDropDownStyle = 14;
 			
-			// aapt resource value: 0
-			public static int UAWebView_mixed_content_mode = 0;
+			// aapt resource value: 15
+			public static int AppCompatTheme_actionMenuTextAppearance = 15;
 			
-			// aapt resource value: { 0x1010001,0x1010002 }
-			public static int[] UrbanAirshipActionButton = new int[] {
-					16842753,
-					16842754};
+			// aapt resource value: 16
+			public static int AppCompatTheme_actionMenuTextColor = 16;
+			
+			// aapt resource value: 17
+			public static int AppCompatTheme_actionModeBackground = 17;
+			
+			// aapt resource value: 18
+			public static int AppCompatTheme_actionModeCloseButtonStyle = 18;
+			
+			// aapt resource value: 19
+			public static int AppCompatTheme_actionModeCloseDrawable = 19;
+			
+			// aapt resource value: 20
+			public static int AppCompatTheme_actionModeCopyDrawable = 20;
+			
+			// aapt resource value: 21
+			public static int AppCompatTheme_actionModeCutDrawable = 21;
+			
+			// aapt resource value: 22
+			public static int AppCompatTheme_actionModeFindDrawable = 22;
+			
+			// aapt resource value: 23
+			public static int AppCompatTheme_actionModePasteDrawable = 23;
+			
+			// aapt resource value: 24
+			public static int AppCompatTheme_actionModePopupWindowStyle = 24;
+			
+			// aapt resource value: 25
+			public static int AppCompatTheme_actionModeSelectAllDrawable = 25;
+			
+			// aapt resource value: 26
+			public static int AppCompatTheme_actionModeShareDrawable = 26;
+			
+			// aapt resource value: 27
+			public static int AppCompatTheme_actionModeSplitBackground = 27;
+			
+			// aapt resource value: 28
+			public static int AppCompatTheme_actionModeStyle = 28;
+			
+			// aapt resource value: 29
+			public static int AppCompatTheme_actionModeWebSearchDrawable = 29;
+			
+			// aapt resource value: 30
+			public static int AppCompatTheme_actionOverflowButtonStyle = 30;
+			
+			// aapt resource value: 31
+			public static int AppCompatTheme_actionOverflowMenuStyle = 31;
+			
+			// aapt resource value: 32
+			public static int AppCompatTheme_activityChooserViewStyle = 32;
+			
+			// aapt resource value: 33
+			public static int AppCompatTheme_alertDialogButtonGroupStyle = 33;
+			
+			// aapt resource value: 34
+			public static int AppCompatTheme_alertDialogCenterButtons = 34;
+			
+			// aapt resource value: 35
+			public static int AppCompatTheme_alertDialogStyle = 35;
+			
+			// aapt resource value: 36
+			public static int AppCompatTheme_alertDialogTheme = 36;
 			
 			// aapt resource value: 1
-			public static int UrbanAirshipActionButton_android_icon = 1;
+			public static int AppCompatTheme_android_windowAnimationStyle = 1;
 			
 			// aapt resource value: 0
-			public static int UrbanAirshipActionButton_android_label = 0;
+			public static int AppCompatTheme_android_windowIsFloating = 0;
 			
-			// aapt resource value: { 0x7F03000D,0x7F030010,0x7F030011 }
-			public static int[] UrbanAirshipInAppButtonLayout = new int[] {
-					2130903053,
-					2130903056,
-					2130903057};
+			// aapt resource value: 37
+			public static int AppCompatTheme_autoCompleteTextViewStyle = 37;
+			
+			// aapt resource value: 38
+			public static int AppCompatTheme_borderlessButtonStyle = 38;
+			
+			// aapt resource value: 39
+			public static int AppCompatTheme_buttonBarButtonStyle = 39;
+			
+			// aapt resource value: 40
+			public static int AppCompatTheme_buttonBarNegativeButtonStyle = 40;
+			
+			// aapt resource value: 41
+			public static int AppCompatTheme_buttonBarNeutralButtonStyle = 41;
+			
+			// aapt resource value: 42
+			public static int AppCompatTheme_buttonBarPositiveButtonStyle = 42;
+			
+			// aapt resource value: 43
+			public static int AppCompatTheme_buttonBarStyle = 43;
+			
+			// aapt resource value: 44
+			public static int AppCompatTheme_buttonStyle = 44;
+			
+			// aapt resource value: 45
+			public static int AppCompatTheme_buttonStyleSmall = 45;
+			
+			// aapt resource value: 46
+			public static int AppCompatTheme_checkboxStyle = 46;
+			
+			// aapt resource value: 47
+			public static int AppCompatTheme_checkedTextViewStyle = 47;
+			
+			// aapt resource value: 48
+			public static int AppCompatTheme_colorAccent = 48;
+			
+			// aapt resource value: 49
+			public static int AppCompatTheme_colorBackgroundFloating = 49;
+			
+			// aapt resource value: 50
+			public static int AppCompatTheme_colorButtonNormal = 50;
+			
+			// aapt resource value: 51
+			public static int AppCompatTheme_colorControlActivated = 51;
+			
+			// aapt resource value: 52
+			public static int AppCompatTheme_colorControlHighlight = 52;
+			
+			// aapt resource value: 53
+			public static int AppCompatTheme_colorControlNormal = 53;
+			
+			// aapt resource value: 54
+			public static int AppCompatTheme_colorError = 54;
+			
+			// aapt resource value: 55
+			public static int AppCompatTheme_colorPrimary = 55;
+			
+			// aapt resource value: 56
+			public static int AppCompatTheme_colorPrimaryDark = 56;
+			
+			// aapt resource value: 57
+			public static int AppCompatTheme_colorSwitchThumbNormal = 57;
+			
+			// aapt resource value: 58
+			public static int AppCompatTheme_controlBackground = 58;
+			
+			// aapt resource value: 59
+			public static int AppCompatTheme_dialogCornerRadius = 59;
+			
+			// aapt resource value: 60
+			public static int AppCompatTheme_dialogPreferredPadding = 60;
+			
+			// aapt resource value: 61
+			public static int AppCompatTheme_dialogTheme = 61;
+			
+			// aapt resource value: 62
+			public static int AppCompatTheme_dividerHorizontal = 62;
+			
+			// aapt resource value: 63
+			public static int AppCompatTheme_dividerVertical = 63;
+			
+			// aapt resource value: 65
+			public static int AppCompatTheme_dropdownListPreferredItemHeight = 65;
+			
+			// aapt resource value: 64
+			public static int AppCompatTheme_dropDownListViewStyle = 64;
+			
+			// aapt resource value: 66
+			public static int AppCompatTheme_editTextBackground = 66;
+			
+			// aapt resource value: 67
+			public static int AppCompatTheme_editTextColor = 67;
+			
+			// aapt resource value: 68
+			public static int AppCompatTheme_editTextStyle = 68;
+			
+			// aapt resource value: 69
+			public static int AppCompatTheme_homeAsUpIndicator = 69;
+			
+			// aapt resource value: 70
+			public static int AppCompatTheme_imageButtonStyle = 70;
+			
+			// aapt resource value: 71
+			public static int AppCompatTheme_listChoiceBackgroundIndicator = 71;
+			
+			// aapt resource value: 72
+			public static int AppCompatTheme_listDividerAlertDialog = 72;
+			
+			// aapt resource value: 73
+			public static int AppCompatTheme_listMenuViewStyle = 73;
+			
+			// aapt resource value: 74
+			public static int AppCompatTheme_listPopupWindowStyle = 74;
+			
+			// aapt resource value: 75
+			public static int AppCompatTheme_listPreferredItemHeight = 75;
+			
+			// aapt resource value: 76
+			public static int AppCompatTheme_listPreferredItemHeightLarge = 76;
+			
+			// aapt resource value: 77
+			public static int AppCompatTheme_listPreferredItemHeightSmall = 77;
+			
+			// aapt resource value: 78
+			public static int AppCompatTheme_listPreferredItemPaddingLeft = 78;
+			
+			// aapt resource value: 79
+			public static int AppCompatTheme_listPreferredItemPaddingRight = 79;
+			
+			// aapt resource value: 80
+			public static int AppCompatTheme_panelBackground = 80;
+			
+			// aapt resource value: 81
+			public static int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 82
+			public static int AppCompatTheme_panelMenuListWidth = 82;
+			
+			// aapt resource value: 83
+			public static int AppCompatTheme_popupMenuStyle = 83;
+			
+			// aapt resource value: 84
+			public static int AppCompatTheme_popupWindowStyle = 84;
+			
+			// aapt resource value: 85
+			public static int AppCompatTheme_radioButtonStyle = 85;
+			
+			// aapt resource value: 86
+			public static int AppCompatTheme_ratingBarStyle = 86;
+			
+			// aapt resource value: 87
+			public static int AppCompatTheme_ratingBarStyleIndicator = 87;
+			
+			// aapt resource value: 88
+			public static int AppCompatTheme_ratingBarStyleSmall = 88;
+			
+			// aapt resource value: 89
+			public static int AppCompatTheme_searchViewStyle = 89;
+			
+			// aapt resource value: 90
+			public static int AppCompatTheme_seekBarStyle = 90;
+			
+			// aapt resource value: 91
+			public static int AppCompatTheme_selectableItemBackground = 91;
+			
+			// aapt resource value: 92
+			public static int AppCompatTheme_selectableItemBackgroundBorderless = 92;
+			
+			// aapt resource value: 93
+			public static int AppCompatTheme_spinnerDropDownItemStyle = 93;
+			
+			// aapt resource value: 94
+			public static int AppCompatTheme_spinnerStyle = 94;
+			
+			// aapt resource value: 95
+			public static int AppCompatTheme_switchStyle = 95;
+			
+			// aapt resource value: 96
+			public static int AppCompatTheme_textAppearanceLargePopupMenu = 96;
+			
+			// aapt resource value: 97
+			public static int AppCompatTheme_textAppearanceListItem = 97;
+			
+			// aapt resource value: 98
+			public static int AppCompatTheme_textAppearanceListItemSecondary = 98;
+			
+			// aapt resource value: 99
+			public static int AppCompatTheme_textAppearanceListItemSmall = 99;
+			
+			// aapt resource value: 100
+			public static int AppCompatTheme_textAppearancePopupMenuHeader = 100;
+			
+			// aapt resource value: 101
+			public static int AppCompatTheme_textAppearanceSearchResultSubtitle = 101;
+			
+			// aapt resource value: 102
+			public static int AppCompatTheme_textAppearanceSearchResultTitle = 102;
+			
+			// aapt resource value: 103
+			public static int AppCompatTheme_textAppearanceSmallPopupMenu = 103;
+			
+			// aapt resource value: 104
+			public static int AppCompatTheme_textColorAlertDialogListItem = 104;
+			
+			// aapt resource value: 105
+			public static int AppCompatTheme_textColorSearchUrl = 105;
+			
+			// aapt resource value: 106
+			public static int AppCompatTheme_toolbarNavigationButtonStyle = 106;
+			
+			// aapt resource value: 107
+			public static int AppCompatTheme_toolbarStyle = 107;
+			
+			// aapt resource value: 108
+			public static int AppCompatTheme_tooltipForegroundColor = 108;
+			
+			// aapt resource value: 109
+			public static int AppCompatTheme_tooltipFrameBackground = 109;
+			
+			// aapt resource value: 110
+			public static int AppCompatTheme_viewInflaterClass = 110;
+			
+			// aapt resource value: 111
+			public static int AppCompatTheme_windowActionBar = 111;
+			
+			// aapt resource value: 112
+			public static int AppCompatTheme_windowActionBarOverlay = 112;
+			
+			// aapt resource value: 113
+			public static int AppCompatTheme_windowActionModeOverlay = 113;
+			
+			// aapt resource value: 114
+			public static int AppCompatTheme_windowFixedHeightMajor = 114;
+			
+			// aapt resource value: 115
+			public static int AppCompatTheme_windowFixedHeightMinor = 115;
+			
+			// aapt resource value: 116
+			public static int AppCompatTheme_windowFixedWidthMajor = 116;
+			
+			// aapt resource value: 117
+			public static int AppCompatTheme_windowFixedWidthMinor = 117;
+			
+			// aapt resource value: 118
+			public static int AppCompatTheme_windowMinWidthMajor = 118;
+			
+			// aapt resource value: 119
+			public static int AppCompatTheme_windowMinWidthMinor = 119;
+			
+			// aapt resource value: 120
+			public static int AppCompatTheme_windowNoTitle = 120;
+			
+			// aapt resource value: { 0x7F030034,0x7F0300C3,0x7F0300C4,0x7F0300C5,0x7F0300C6,0x7F0300E5 }
+			public static int[] BottomAppBar = new int[] {
+					2130903092,
+					2130903235,
+					2130903236,
+					2130903237,
+					2130903238,
+					2130903269};
 			
 			// aapt resource value: 0
-			public static int UrbanAirshipInAppButtonLayout_urbanAirshipButtonLayoutResourceId = 0;
+			public static int BottomAppBar_backgroundTint = 0;
 			
 			// aapt resource value: 1
-			public static int UrbanAirshipInAppButtonLayout_urbanAirshipSeparatedSpaceWidth = 1;
+			public static int BottomAppBar_fabAlignmentMode = 1;
 			
 			// aapt resource value: 2
-			public static int UrbanAirshipInAppButtonLayout_urbanAirshipStackedSpaceHeight = 2;
+			public static int BottomAppBar_fabCradleMargin = 2;
 			
-			// aapt resource value: { 0x7F03000E,0x7F03000F }
-			public static int[] UrbanAirshipLayout = new int[] {
-					2130903054,
-					2130903055};
+			// aapt resource value: 3
+			public static int BottomAppBar_fabCradleRoundedCornerRadius = 3;
+			
+			// aapt resource value: 4
+			public static int BottomAppBar_fabCradleVerticalOffset = 4;
+			
+			// aapt resource value: 5
+			public static int BottomAppBar_hideOnScroll = 5;
+			
+			// aapt resource value: { 0x7F0300B5,0x7F0300FA,0x7F0300FC,0x7F0300FE,0x7F0300FF,0x7F030103,0x7F030104,0x7F030105,0x7F030107,0x7F03012B }
+			public static int[] BottomNavigationView = new int[] {
+					2130903221,
+					2130903290,
+					2130903292,
+					2130903294,
+					2130903295,
+					2130903299,
+					2130903300,
+					2130903301,
+					2130903303,
+					2130903339};
 			
 			// aapt resource value: 0
-			public static int UrbanAirshipLayout_urbanAirshipMaxHeight = 0;
+			public static int BottomNavigationView_elevation = 0;
 			
 			// aapt resource value: 1
-			public static int UrbanAirshipLayout_urbanAirshipMaxWidth = 1;
+			public static int BottomNavigationView_itemBackground = 1;
+			
+			// aapt resource value: 2
+			public static int BottomNavigationView_itemHorizontalTranslationEnabled = 2;
+			
+			// aapt resource value: 3
+			public static int BottomNavigationView_itemIconSize = 3;
+			
+			// aapt resource value: 4
+			public static int BottomNavigationView_itemIconTint = 4;
+			
+			// aapt resource value: 5
+			public static int BottomNavigationView_itemTextAppearanceActive = 5;
+			
+			// aapt resource value: 6
+			public static int BottomNavigationView_itemTextAppearanceInactive = 6;
+			
+			// aapt resource value: 7
+			public static int BottomNavigationView_itemTextColor = 7;
+			
+			// aapt resource value: 8
+			public static int BottomNavigationView_labelVisibilityMode = 8;
+			
+			// aapt resource value: 9
+			public static int BottomNavigationView_menu = 9;
+			
+			// aapt resource value: { 0x7F030038,0x7F030039,0x7F03003B,0x7F03003C }
+			public static int[] BottomSheetBehavior_Layout = new int[] {
+					2130903096,
+					2130903097,
+					2130903099,
+					2130903100};
+			
+			// aapt resource value: 0
+			public static int BottomSheetBehavior_Layout_behavior_fitToContents = 0;
+			
+			// aapt resource value: 1
+			public static int BottomSheetBehavior_Layout_behavior_hideable = 1;
+			
+			// aapt resource value: 2
+			public static int BottomSheetBehavior_Layout_behavior_peekHeight = 2;
+			
+			// aapt resource value: 3
+			public static int BottomSheetBehavior_Layout_behavior_skipCollapsed = 3;
+			
+			// aapt resource value: { 0x7F030026 }
+			public static int[] ButtonBarLayout = new int[] {
+					2130903078};
+			
+			// aapt resource value: 0
+			public static int ButtonBarLayout_allowStacking = 0;
+			
+			// aapt resource value: { 0x101013F,0x1010140,0x7F030058,0x7F030059,0x7F03005A,0x7F03005B,0x7F03005C,0x7F03005D,0x7F030097,0x7F030098,0x7F030099,0x7F03009A,0x7F03009B }
+			public static int[] CardView = new int[] {
+					16843071,
+					16843072,
+					2130903128,
+					2130903129,
+					2130903130,
+					2130903131,
+					2130903132,
+					2130903133,
+					2130903191,
+					2130903192,
+					2130903193,
+					2130903194,
+					2130903195};
+			
+			// aapt resource value: 1
+			public static int CardView_android_minHeight = 1;
+			
+			// aapt resource value: 0
+			public static int CardView_android_minWidth = 0;
+			
+			// aapt resource value: 2
+			public static int CardView_cardBackgroundColor = 2;
+			
+			// aapt resource value: 3
+			public static int CardView_cardCornerRadius = 3;
+			
+			// aapt resource value: 4
+			public static int CardView_cardElevation = 4;
+			
+			// aapt resource value: 5
+			public static int CardView_cardMaxElevation = 5;
+			
+			// aapt resource value: 6
+			public static int CardView_cardPreventCornerOverlap = 6;
+			
+			// aapt resource value: 7
+			public static int CardView_cardUseCompatPadding = 7;
+			
+			// aapt resource value: 8
+			public static int CardView_contentPadding = 8;
+			
+			// aapt resource value: 9
+			public static int CardView_contentPaddingBottom = 9;
+			
+			// aapt resource value: 10
+			public static int CardView_contentPaddingLeft = 10;
+			
+			// aapt resource value: 11
+			public static int CardView_contentPaddingRight = 11;
+			
+			// aapt resource value: 12
+			public static int CardView_contentPaddingTop = 12;
+			
+			// aapt resource value: { 0x1010034,0x10100AB,0x101011F,0x101014F,0x10101E5,0x7F030061,0x7F030062,0x7F030063,0x7F030065,0x7F030066,0x7F030067,0x7F030069,0x7F03006A,0x7F03006B,0x7F03006C,0x7F03006D,0x7F03006E,0x7F030073,0x7F030074,0x7F030075,0x7F030077,0x7F030078,0x7F030079,0x7F03007A,0x7F03007B,0x7F03007C,0x7F03007D,0x7F0300E3,0x7F0300ED,0x7F0300F1,0x7F03014D,0x7F030159,0x7F0301AE,0x7F0301B0 }
+			public static int[] Chip = new int[] {
+					16842804,
+					16842923,
+					16843039,
+					16843087,
+					16843237,
+					2130903137,
+					2130903138,
+					2130903139,
+					2130903141,
+					2130903142,
+					2130903143,
+					2130903145,
+					2130903146,
+					2130903147,
+					2130903148,
+					2130903149,
+					2130903150,
+					2130903155,
+					2130903156,
+					2130903157,
+					2130903159,
+					2130903160,
+					2130903161,
+					2130903162,
+					2130903163,
+					2130903164,
+					2130903165,
+					2130903267,
+					2130903277,
+					2130903281,
+					2130903373,
+					2130903385,
+					2130903470,
+					2130903472};
+			
+			// aapt resource value: { 0x7F030060,0x7F03006F,0x7F030070,0x7F030071,0x7F03015D,0x7F03015E }
+			public static int[] ChipGroup = new int[] {
+					2130903136,
+					2130903151,
+					2130903152,
+					2130903153,
+					2130903389,
+					2130903390};
+			
+			// aapt resource value: 0
+			public static int ChipGroup_checkedChip = 0;
+			
+			// aapt resource value: 1
+			public static int ChipGroup_chipSpacing = 1;
+			
+			// aapt resource value: 2
+			public static int ChipGroup_chipSpacingHorizontal = 2;
+			
+			// aapt resource value: 3
+			public static int ChipGroup_chipSpacingVertical = 3;
+			
+			// aapt resource value: 4
+			public static int ChipGroup_singleLine = 4;
+			
+			// aapt resource value: 5
+			public static int ChipGroup_singleSelection = 5;
+			
+			// aapt resource value: 4
+			public static int Chip_android_checkable = 4;
+			
+			// aapt resource value: 1
+			public static int Chip_android_ellipsize = 1;
+			
+			// aapt resource value: 2
+			public static int Chip_android_maxWidth = 2;
+			
+			// aapt resource value: 3
+			public static int Chip_android_text = 3;
+			
+			// aapt resource value: 0
+			public static int Chip_android_textAppearance = 0;
+			
+			// aapt resource value: 5
+			public static int Chip_checkedIcon = 5;
+			
+			// aapt resource value: 6
+			public static int Chip_checkedIconEnabled = 6;
+			
+			// aapt resource value: 7
+			public static int Chip_checkedIconVisible = 7;
+			
+			// aapt resource value: 8
+			public static int Chip_chipBackgroundColor = 8;
+			
+			// aapt resource value: 9
+			public static int Chip_chipCornerRadius = 9;
+			
+			// aapt resource value: 10
+			public static int Chip_chipEndPadding = 10;
+			
+			// aapt resource value: 11
+			public static int Chip_chipIcon = 11;
+			
+			// aapt resource value: 12
+			public static int Chip_chipIconEnabled = 12;
+			
+			// aapt resource value: 13
+			public static int Chip_chipIconSize = 13;
+			
+			// aapt resource value: 14
+			public static int Chip_chipIconTint = 14;
+			
+			// aapt resource value: 15
+			public static int Chip_chipIconVisible = 15;
+			
+			// aapt resource value: 16
+			public static int Chip_chipMinHeight = 16;
+			
+			// aapt resource value: 17
+			public static int Chip_chipStartPadding = 17;
+			
+			// aapt resource value: 18
+			public static int Chip_chipStrokeColor = 18;
+			
+			// aapt resource value: 19
+			public static int Chip_chipStrokeWidth = 19;
+			
+			// aapt resource value: 20
+			public static int Chip_closeIcon = 20;
+			
+			// aapt resource value: 21
+			public static int Chip_closeIconEnabled = 21;
+			
+			// aapt resource value: 22
+			public static int Chip_closeIconEndPadding = 22;
+			
+			// aapt resource value: 23
+			public static int Chip_closeIconSize = 23;
+			
+			// aapt resource value: 24
+			public static int Chip_closeIconStartPadding = 24;
+			
+			// aapt resource value: 25
+			public static int Chip_closeIconTint = 25;
+			
+			// aapt resource value: 26
+			public static int Chip_closeIconVisible = 26;
+			
+			// aapt resource value: 27
+			public static int Chip_hideMotionSpec = 27;
+			
+			// aapt resource value: 28
+			public static int Chip_iconEndPadding = 28;
+			
+			// aapt resource value: 29
+			public static int Chip_iconStartPadding = 29;
+			
+			// aapt resource value: 30
+			public static int Chip_rippleColor = 30;
+			
+			// aapt resource value: 31
+			public static int Chip_showMotionSpec = 31;
+			
+			// aapt resource value: 32
+			public static int Chip_textEndPadding = 32;
+			
+			// aapt resource value: 33
+			public static int Chip_textStartPadding = 33;
+			
+			// aapt resource value: { 0x7F030081,0x7F030082,0x7F03009C,0x7F0300BC,0x7F0300BD,0x7F0300BE,0x7F0300BF,0x7F0300C0,0x7F0300C1,0x7F0300C2,0x7F03014E,0x7F030150,0x7F03016E,0x7F0301BB,0x7F0301BC,0x7F0301C6 }
+			public static int[] CollapsingToolbarLayout = new int[] {
+					2130903169,
+					2130903170,
+					2130903196,
+					2130903228,
+					2130903229,
+					2130903230,
+					2130903231,
+					2130903232,
+					2130903233,
+					2130903234,
+					2130903374,
+					2130903376,
+					2130903406,
+					2130903483,
+					2130903484,
+					2130903494};
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_collapsedTitleGravity = 0;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_collapsedTitleTextAppearance = 1;
+			
+			// aapt resource value: 2
+			public static int CollapsingToolbarLayout_contentScrim = 2;
+			
+			// aapt resource value: 3
+			public static int CollapsingToolbarLayout_expandedTitleGravity = 3;
+			
+			// aapt resource value: 4
+			public static int CollapsingToolbarLayout_expandedTitleMargin = 4;
+			
+			// aapt resource value: 5
+			public static int CollapsingToolbarLayout_expandedTitleMarginBottom = 5;
+			
+			// aapt resource value: 6
+			public static int CollapsingToolbarLayout_expandedTitleMarginEnd = 6;
+			
+			// aapt resource value: 7
+			public static int CollapsingToolbarLayout_expandedTitleMarginStart = 7;
+			
+			// aapt resource value: 8
+			public static int CollapsingToolbarLayout_expandedTitleMarginTop = 8;
+			
+			// aapt resource value: 9
+			public static int CollapsingToolbarLayout_expandedTitleTextAppearance = 9;
+			
+			// aapt resource value: { 0x7F03010E,0x7F03010F }
+			public static int[] CollapsingToolbarLayout_Layout = new int[] {
+					2130903310,
+					2130903311};
+			
+			// aapt resource value: 0
+			public static int CollapsingToolbarLayout_Layout_layout_collapseMode = 0;
+			
+			// aapt resource value: 1
+			public static int CollapsingToolbarLayout_Layout_layout_collapseParallaxMultiplier = 1;
+			
+			// aapt resource value: 10
+			public static int CollapsingToolbarLayout_scrimAnimationDuration = 10;
+			
+			// aapt resource value: 11
+			public static int CollapsingToolbarLayout_scrimVisibleHeightTrigger = 11;
+			
+			// aapt resource value: 12
+			public static int CollapsingToolbarLayout_statusBarScrim = 12;
+			
+			// aapt resource value: 13
+			public static int CollapsingToolbarLayout_title = 13;
+			
+			// aapt resource value: 14
+			public static int CollapsingToolbarLayout_titleEnabled = 14;
+			
+			// aapt resource value: 15
+			public static int CollapsingToolbarLayout_toolbarId = 15;
+			
+			// aapt resource value: { 0x10101A5,0x101031F,0x7F030027 }
+			public static int[] ColorStateListItem = new int[] {
+					16843173,
+					16843551,
+					2130903079};
+			
+			// aapt resource value: 2
+			public static int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public static int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public static int ColorStateListItem_android_color = 0;
+			
+			// aapt resource value: { 0x1010107,0x7F030056,0x7F030057 }
+			public static int[] CompoundButton = new int[] {
+					16843015,
+					2130903126,
+					2130903127};
+			
+			// aapt resource value: 0
+			public static int CompoundButton_android_button = 0;
+			
+			// aapt resource value: 1
+			public static int CompoundButton_buttonTint = 1;
+			
+			// aapt resource value: 2
+			public static int CompoundButton_buttonTintMode = 2;
+			
+			// aapt resource value: { 0x7F030106,0x7F03016D }
+			public static int[] CoordinatorLayout = new int[] {
+					2130903302,
+					2130903405};
+			
+			// aapt resource value: 0
+			public static int CoordinatorLayout_keylines = 0;
+			
+			// aapt resource value: { 0x10100B3,0x7F03010B,0x7F03010C,0x7F03010D,0x7F030110,0x7F030111,0x7F030112 }
+			public static int[] CoordinatorLayout_Layout = new int[] {
+					16842931,
+					2130903307,
+					2130903308,
+					2130903309,
+					2130903312,
+					2130903313,
+					2130903314};
+			
+			// aapt resource value: 0
+			public static int CoordinatorLayout_Layout_android_layout_gravity = 0;
+			
+			// aapt resource value: 1
+			public static int CoordinatorLayout_Layout_layout_anchor = 1;
+			
+			// aapt resource value: 2
+			public static int CoordinatorLayout_Layout_layout_anchorGravity = 2;
+			
+			// aapt resource value: 3
+			public static int CoordinatorLayout_Layout_layout_behavior = 3;
+			
+			// aapt resource value: 4
+			public static int CoordinatorLayout_Layout_layout_dodgeInsetEdges = 4;
+			
+			// aapt resource value: 5
+			public static int CoordinatorLayout_Layout_layout_insetEdge = 5;
+			
+			// aapt resource value: 6
+			public static int CoordinatorLayout_Layout_layout_keyline = 6;
+			
+			// aapt resource value: 1
+			public static int CoordinatorLayout_statusBarBackground = 1;
+			
+			// aapt resource value: { 0x7F030041,0x7F030042 }
+			public static int[] DesignTheme = new int[] {
+					2130903105,
+					2130903106};
+			
+			// aapt resource value: 0
+			public static int DesignTheme_bottomSheetDialogTheme = 0;
+			
+			// aapt resource value: 1
+			public static int DesignTheme_bottomSheetStyle = 1;
+			
+			// aapt resource value: { 0x7F030029,0x7F03002A,0x7F030036,0x7F030083,0x7F0300AE,0x7F0300DC,0x7F030162,0x7F0301B2 }
+			public static int[] DrawerArrowToggle = new int[] {
+					2130903081,
+					2130903082,
+					2130903094,
+					2130903171,
+					2130903214,
+					2130903260,
+					2130903394,
+					2130903474};
+			
+			// aapt resource value: 0
+			public static int DrawerArrowToggle_arrowHeadLength = 0;
+			
+			// aapt resource value: 1
+			public static int DrawerArrowToggle_arrowShaftLength = 1;
+			
+			// aapt resource value: 2
+			public static int DrawerArrowToggle_barLength = 2;
+			
+			// aapt resource value: 3
+			public static int DrawerArrowToggle_color = 3;
+			
+			// aapt resource value: 4
+			public static int DrawerArrowToggle_drawableSize = 4;
+			
+			// aapt resource value: 5
+			public static int DrawerArrowToggle_gapBetweenBars = 5;
+			
+			// aapt resource value: 6
+			public static int DrawerArrowToggle_spinBars = 6;
+			
+			// aapt resource value: 7
+			public static int DrawerArrowToggle_thickness = 7;
+			
+			// aapt resource value: { 0x7F030034,0x7F030035,0x7F03003D,0x7F0300B5,0x7F0300C7,0x7F0300C8,0x7F0300E3,0x7F0300EB,0x7F030129,0x7F030143,0x7F03014D,0x7F030159,0x7F0301D0 }
+			public static int[] FloatingActionButton = new int[] {
+					2130903092,
+					2130903093,
+					2130903101,
+					2130903221,
+					2130903239,
+					2130903240,
+					2130903267,
+					2130903275,
+					2130903337,
+					2130903363,
+					2130903373,
+					2130903385,
+					2130903504};
+			
+			// aapt resource value: 0
+			public static int FloatingActionButton_backgroundTint = 0;
+			
+			// aapt resource value: 1
+			public static int FloatingActionButton_backgroundTintMode = 1;
+			
+			// aapt resource value: { 0x7F030037 }
+			public static int[] FloatingActionButton_Behavior_Layout = new int[] {
+					2130903095};
+			
+			// aapt resource value: 0
+			public static int FloatingActionButton_Behavior_Layout_behavior_autoHide = 0;
+			
+			// aapt resource value: 2
+			public static int FloatingActionButton_borderWidth = 2;
+			
+			// aapt resource value: 3
+			public static int FloatingActionButton_elevation = 3;
+			
+			// aapt resource value: 4
+			public static int FloatingActionButton_fabCustomSize = 4;
+			
+			// aapt resource value: 5
+			public static int FloatingActionButton_fabSize = 5;
+			
+			// aapt resource value: 6
+			public static int FloatingActionButton_hideMotionSpec = 6;
+			
+			// aapt resource value: 7
+			public static int FloatingActionButton_hoveredFocusedTranslationZ = 7;
+			
+			// aapt resource value: 8
+			public static int FloatingActionButton_maxImageSize = 8;
+			
+			// aapt resource value: 9
+			public static int FloatingActionButton_pressedTranslationZ = 9;
+			
+			// aapt resource value: 10
+			public static int FloatingActionButton_rippleColor = 10;
+			
+			// aapt resource value: 11
+			public static int FloatingActionButton_showMotionSpec = 11;
+			
+			// aapt resource value: 12
+			public static int FloatingActionButton_useCompatPadding = 12;
+			
+			// aapt resource value: { 0x7F030101,0x7F030117 }
+			public static int[] FlowLayout = new int[] {
+					2130903297,
+					2130903319};
+			
+			// aapt resource value: 0
+			public static int FlowLayout_itemSpacing = 0;
+			
+			// aapt resource value: 1
+			public static int FlowLayout_lineSpacing = 1;
+			
+			// aapt resource value: { 0x7F0300D2,0x7F0300D3,0x7F0300D4,0x7F0300D5,0x7F0300D6,0x7F0300D7 }
+			public static int[] FontFamily = new int[] {
+					2130903250,
+					2130903251,
+					2130903252,
+					2130903253,
+					2130903254,
+					2130903255};
+			
+			// aapt resource value: { 0x1010532,0x1010533,0x101053F,0x101056F,0x1010570,0x7F0300D0,0x7F0300D8,0x7F0300D9,0x7F0300DA,0x7F0301CF }
+			public static int[] FontFamilyFont = new int[] {
+					16844082,
+					16844083,
+					16844095,
+					16844143,
+					16844144,
+					2130903248,
+					2130903256,
+					2130903257,
+					2130903258,
+					2130903503};
+			
+			// aapt resource value: 0
+			public static int FontFamilyFont_android_font = 0;
+			
+			// aapt resource value: 2
+			public static int FontFamilyFont_android_fontStyle = 2;
+			
+			// aapt resource value: 4
+			public static int FontFamilyFont_android_fontVariationSettings = 4;
+			
+			// aapt resource value: 1
+			public static int FontFamilyFont_android_fontWeight = 1;
+			
+			// aapt resource value: 3
+			public static int FontFamilyFont_android_ttcIndex = 3;
+			
+			// aapt resource value: 5
+			public static int FontFamilyFont_font = 5;
+			
+			// aapt resource value: 6
+			public static int FontFamilyFont_fontStyle = 6;
+			
+			// aapt resource value: 7
+			public static int FontFamilyFont_fontVariationSettings = 7;
+			
+			// aapt resource value: 8
+			public static int FontFamilyFont_fontWeight = 8;
+			
+			// aapt resource value: 9
+			public static int FontFamilyFont_ttcIndex = 9;
+			
+			// aapt resource value: 0
+			public static int FontFamily_fontProviderAuthority = 0;
+			
+			// aapt resource value: 1
+			public static int FontFamily_fontProviderCerts = 1;
+			
+			// aapt resource value: 2
+			public static int FontFamily_fontProviderFetchStrategy = 2;
+			
+			// aapt resource value: 3
+			public static int FontFamily_fontProviderFetchTimeout = 3;
+			
+			// aapt resource value: 4
+			public static int FontFamily_fontProviderPackage = 4;
+			
+			// aapt resource value: 5
+			public static int FontFamily_fontProviderQuery = 5;
+			
+			// aapt resource value: { 0x1010109,0x1010200,0x7F0300DB }
+			public static int[] ForegroundLinearLayout = new int[] {
+					16843017,
+					16843264,
+					2130903259};
+			
+			// aapt resource value: 0
+			public static int ForegroundLinearLayout_android_foreground = 0;
+			
+			// aapt resource value: 1
+			public static int ForegroundLinearLayout_android_foregroundGravity = 1;
+			
+			// aapt resource value: 2
+			public static int ForegroundLinearLayout_foregroundInsidePadding = 2;
+			
+			// aapt resource value: { 0x101019D,0x101019E,0x10101A1,0x10101A2,0x10101A3,0x10101A4,0x1010201,0x101020B,0x1010510,0x1010511,0x1010512,0x1010513 }
+			public static int[] GradientColor = new int[] {
+					16843165,
+					16843166,
+					16843169,
+					16843170,
+					16843171,
+					16843172,
+					16843265,
+					16843275,
+					16844048,
+					16844049,
+					16844050,
+					16844051};
+			
+			// aapt resource value: { 0x10101A5,0x1010514 }
+			public static int[] GradientColorItem = new int[] {
+					16843173,
+					16844052};
+			
+			// aapt resource value: 0
+			public static int GradientColorItem_android_color = 0;
+			
+			// aapt resource value: 1
+			public static int GradientColorItem_android_offset = 1;
+			
+			// aapt resource value: 7
+			public static int GradientColor_android_centerColor = 7;
+			
+			// aapt resource value: 3
+			public static int GradientColor_android_centerX = 3;
+			
+			// aapt resource value: 4
+			public static int GradientColor_android_centerY = 4;
+			
+			// aapt resource value: 1
+			public static int GradientColor_android_endColor = 1;
+			
+			// aapt resource value: 10
+			public static int GradientColor_android_endX = 10;
+			
+			// aapt resource value: 11
+			public static int GradientColor_android_endY = 11;
+			
+			// aapt resource value: 5
+			public static int GradientColor_android_gradientRadius = 5;
+			
+			// aapt resource value: 0
+			public static int GradientColor_android_startColor = 0;
+			
+			// aapt resource value: 8
+			public static int GradientColor_android_startX = 8;
+			
+			// aapt resource value: 9
+			public static int GradientColor_android_startY = 9;
+			
+			// aapt resource value: 6
+			public static int GradientColor_android_tileMode = 6;
+			
+			// aapt resource value: 2
+			public static int GradientColor_android_type = 2;
+			
+			// aapt resource value: { 0x10100AF,0x10100C4,0x1010126,0x1010127,0x1010128,0x7F0300AA,0x7F0300AC,0x7F03012A,0x7F030158 }
+			public static int[] LinearLayoutCompat = new int[] {
+					16842927,
+					16842948,
+					16843046,
+					16843047,
+					16843048,
+					2130903210,
+					2130903212,
+					2130903338,
+					2130903384};
+			
+			// aapt resource value: 2
+			public static int LinearLayoutCompat_android_baselineAligned = 2;
+			
+			// aapt resource value: 3
+			public static int LinearLayoutCompat_android_baselineAlignedChildIndex = 3;
+			
+			// aapt resource value: 0
+			public static int LinearLayoutCompat_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public static int LinearLayoutCompat_android_orientation = 1;
+			
+			// aapt resource value: 4
+			public static int LinearLayoutCompat_android_weightSum = 4;
+			
+			// aapt resource value: 5
+			public static int LinearLayoutCompat_divider = 5;
+			
+			// aapt resource value: 6
+			public static int LinearLayoutCompat_dividerPadding = 6;
+			
+			// aapt resource value: { 0x10100B3,0x10100F4,0x10100F5,0x1010181 }
+			public static int[] LinearLayoutCompat_Layout = new int[] {
+					16842931,
+					16842996,
+					16842997,
+					16843137};
+			
+			// aapt resource value: 0
+			public static int LinearLayoutCompat_Layout_android_layout_gravity = 0;
+			
+			// aapt resource value: 2
+			public static int LinearLayoutCompat_Layout_android_layout_height = 2;
+			
+			// aapt resource value: 3
+			public static int LinearLayoutCompat_Layout_android_layout_weight = 3;
+			
+			// aapt resource value: 1
+			public static int LinearLayoutCompat_Layout_android_layout_width = 1;
+			
+			// aapt resource value: 7
+			public static int LinearLayoutCompat_measureWithLargestChild = 7;
+			
+			// aapt resource value: 8
+			public static int LinearLayoutCompat_showDividers = 8;
+			
+			// aapt resource value: { 0x10102AC,0x10102AD }
+			public static int[] ListPopupWindow = new int[] {
+					16843436,
+					16843437};
+			
+			// aapt resource value: 0
+			public static int ListPopupWindow_android_dropDownHorizontalOffset = 0;
+			
+			// aapt resource value: 1
+			public static int ListPopupWindow_android_dropDownVerticalOffset = 1;
+			
+			// aapt resource value: { 0x10101B7,0x10101B8,0x10101B9,0x10101BA,0x7F030034,0x7F030035,0x7F03009F,0x7F0300EC,0x7F0300EE,0x7F0300EF,0x7F0300F0,0x7F0300F2,0x7F0300F3,0x7F03014D,0x7F03016F,0x7F030170 }
+			public static int[] MaterialButton = new int[] {
+					16843191,
+					16843192,
+					16843193,
+					16843194,
+					2130903092,
+					2130903093,
+					2130903199,
+					2130903276,
+					2130903278,
+					2130903279,
+					2130903280,
+					2130903282,
+					2130903283,
+					2130903373,
+					2130903407,
+					2130903408};
+			
+			// aapt resource value: 3
+			public static int MaterialButton_android_insetBottom = 3;
+			
+			// aapt resource value: 0
+			public static int MaterialButton_android_insetLeft = 0;
+			
+			// aapt resource value: 1
+			public static int MaterialButton_android_insetRight = 1;
+			
+			// aapt resource value: 2
+			public static int MaterialButton_android_insetTop = 2;
+			
+			// aapt resource value: 4
+			public static int MaterialButton_backgroundTint = 4;
+			
+			// aapt resource value: 5
+			public static int MaterialButton_backgroundTintMode = 5;
+			
+			// aapt resource value: 6
+			public static int MaterialButton_cornerRadius = 6;
+			
+			// aapt resource value: 7
+			public static int MaterialButton_icon = 7;
+			
+			// aapt resource value: 8
+			public static int MaterialButton_iconGravity = 8;
+			
+			// aapt resource value: 9
+			public static int MaterialButton_iconPadding = 9;
+			
+			// aapt resource value: 10
+			public static int MaterialButton_iconSize = 10;
+			
+			// aapt resource value: 11
+			public static int MaterialButton_iconTint = 11;
+			
+			// aapt resource value: 12
+			public static int MaterialButton_iconTintMode = 12;
+			
+			// aapt resource value: 13
+			public static int MaterialButton_rippleColor = 13;
+			
+			// aapt resource value: 14
+			public static int MaterialButton_strokeColor = 14;
+			
+			// aapt resource value: 15
+			public static int MaterialButton_strokeWidth = 15;
+			
+			// aapt resource value: { 0x7F03016F,0x7F030170 }
+			public static int[] MaterialCardView = new int[] {
+					2130903407,
+					2130903408};
+			
+			// aapt resource value: 0
+			public static int MaterialCardView_strokeColor = 0;
+			
+			// aapt resource value: 1
+			public static int MaterialCardView_strokeWidth = 1;
+			
+			// aapt resource value: { 0x7F030041,0x7F030042,0x7F030068,0x7F030072,0x7F030076,0x7F030084,0x7F030085,0x7F03008B,0x7F03008C,0x7F03008D,0x7F0300B4,0x7F0300CF,0x7F030125,0x7F030126,0x7F030130,0x7F03014F,0x7F03015F,0x7F030192,0x7F030197,0x7F030198,0x7F030199,0x7F03019A,0x7F03019B,0x7F03019C,0x7F03019D,0x7F03019E,0x7F03019F,0x7F0301A0,0x7F0301A5,0x7F0301AA,0x7F0301AB,0x7F0301AF }
+			public static int[] MaterialComponentsTheme = new int[] {
+					2130903105,
+					2130903106,
+					2130903144,
+					2130903154,
+					2130903158,
+					2130903172,
+					2130903173,
+					2130903179,
+					2130903180,
+					2130903181,
+					2130903220,
+					2130903247,
+					2130903333,
+					2130903334,
+					2130903344,
+					2130903375,
+					2130903391,
+					2130903442,
+					2130903447,
+					2130903448,
+					2130903449,
+					2130903450,
+					2130903451,
+					2130903452,
+					2130903453,
+					2130903454,
+					2130903455,
+					2130903456,
+					2130903461,
+					2130903466,
+					2130903467,
+					2130903471};
+			
+			// aapt resource value: 0
+			public static int MaterialComponentsTheme_bottomSheetDialogTheme = 0;
+			
+			// aapt resource value: 1
+			public static int MaterialComponentsTheme_bottomSheetStyle = 1;
+			
+			// aapt resource value: 2
+			public static int MaterialComponentsTheme_chipGroupStyle = 2;
+			
+			// aapt resource value: 3
+			public static int MaterialComponentsTheme_chipStandaloneStyle = 3;
+			
+			// aapt resource value: 4
+			public static int MaterialComponentsTheme_chipStyle = 4;
+			
+			// aapt resource value: 5
+			public static int MaterialComponentsTheme_colorAccent = 5;
+			
+			// aapt resource value: 6
+			public static int MaterialComponentsTheme_colorBackgroundFloating = 6;
+			
+			// aapt resource value: 7
+			public static int MaterialComponentsTheme_colorPrimary = 7;
+			
+			// aapt resource value: 8
+			public static int MaterialComponentsTheme_colorPrimaryDark = 8;
+			
+			// aapt resource value: 9
+			public static int MaterialComponentsTheme_colorSecondary = 9;
+			
+			// aapt resource value: 10
+			public static int MaterialComponentsTheme_editTextStyle = 10;
+			
+			// aapt resource value: 11
+			public static int MaterialComponentsTheme_floatingActionButtonStyle = 11;
+			
+			// aapt resource value: 12
+			public static int MaterialComponentsTheme_materialButtonStyle = 12;
+			
+			// aapt resource value: 13
+			public static int MaterialComponentsTheme_materialCardViewStyle = 13;
+			
+			// aapt resource value: 14
+			public static int MaterialComponentsTheme_navigationViewStyle = 14;
+			
+			// aapt resource value: 15
+			public static int MaterialComponentsTheme_scrimBackground = 15;
+			
+			// aapt resource value: 16
+			public static int MaterialComponentsTheme_snackbarButtonStyle = 16;
+			
+			// aapt resource value: 17
+			public static int MaterialComponentsTheme_tabStyle = 17;
+			
+			// aapt resource value: 18
+			public static int MaterialComponentsTheme_textAppearanceBody1 = 18;
+			
+			// aapt resource value: 19
+			public static int MaterialComponentsTheme_textAppearanceBody2 = 19;
+			
+			// aapt resource value: 20
+			public static int MaterialComponentsTheme_textAppearanceButton = 20;
+			
+			// aapt resource value: 21
+			public static int MaterialComponentsTheme_textAppearanceCaption = 21;
+			
+			// aapt resource value: 22
+			public static int MaterialComponentsTheme_textAppearanceHeadline1 = 22;
+			
+			// aapt resource value: 23
+			public static int MaterialComponentsTheme_textAppearanceHeadline2 = 23;
+			
+			// aapt resource value: 24
+			public static int MaterialComponentsTheme_textAppearanceHeadline3 = 24;
+			
+			// aapt resource value: 25
+			public static int MaterialComponentsTheme_textAppearanceHeadline4 = 25;
+			
+			// aapt resource value: 26
+			public static int MaterialComponentsTheme_textAppearanceHeadline5 = 26;
+			
+			// aapt resource value: 27
+			public static int MaterialComponentsTheme_textAppearanceHeadline6 = 27;
+			
+			// aapt resource value: 28
+			public static int MaterialComponentsTheme_textAppearanceOverline = 28;
+			
+			// aapt resource value: 29
+			public static int MaterialComponentsTheme_textAppearanceSubtitle1 = 29;
+			
+			// aapt resource value: 30
+			public static int MaterialComponentsTheme_textAppearanceSubtitle2 = 30;
+			
+			// aapt resource value: 31
+			public static int MaterialComponentsTheme_textInputStyle = 31;
+			
+			// aapt resource value: { 0x101000E,0x10100D0,0x1010194,0x10101DE,0x10101DF,0x10101E0 }
+			public static int[] MenuGroup = new int[] {
+					16842766,
+					16842960,
+					16843156,
+					16843230,
+					16843231,
+					16843232};
+			
+			// aapt resource value: 5
+			public static int MenuGroup_android_checkableBehavior = 5;
+			
+			// aapt resource value: 0
+			public static int MenuGroup_android_enabled = 0;
+			
+			// aapt resource value: 1
+			public static int MenuGroup_android_id = 1;
+			
+			// aapt resource value: 3
+			public static int MenuGroup_android_menuCategory = 3;
+			
+			// aapt resource value: 4
+			public static int MenuGroup_android_orderInCategory = 4;
+			
+			// aapt resource value: 2
+			public static int MenuGroup_android_visible = 2;
+			
+			// aapt resource value: { 0x1010002,0x101000E,0x10100D0,0x1010106,0x1010194,0x10101DE,0x10101DF,0x10101E1,0x10101E2,0x10101E3,0x10101E4,0x10101E5,0x101026F,0x7F03000D,0x7F03001F,0x7F030020,0x7F030028,0x7F030090,0x7F0300F2,0x7F0300F3,0x7F030131,0x7F030157,0x7F0301CB }
+			public static int[] MenuItem = new int[] {
+					16842754,
+					16842766,
+					16842960,
+					16843014,
+					16843156,
+					16843230,
+					16843231,
+					16843233,
+					16843234,
+					16843235,
+					16843236,
+					16843237,
+					16843375,
+					2130903053,
+					2130903071,
+					2130903072,
+					2130903080,
+					2130903184,
+					2130903282,
+					2130903283,
+					2130903345,
+					2130903383,
+					2130903499};
+			
+			// aapt resource value: 13
+			public static int MenuItem_actionLayout = 13;
+			
+			// aapt resource value: 14
+			public static int MenuItem_actionProviderClass = 14;
+			
+			// aapt resource value: 15
+			public static int MenuItem_actionViewClass = 15;
+			
+			// aapt resource value: 16
+			public static int MenuItem_alphabeticModifiers = 16;
+			
+			// aapt resource value: 9
+			public static int MenuItem_android_alphabeticShortcut = 9;
+			
+			// aapt resource value: 11
+			public static int MenuItem_android_checkable = 11;
+			
+			// aapt resource value: 3
+			public static int MenuItem_android_checked = 3;
+			
+			// aapt resource value: 1
+			public static int MenuItem_android_enabled = 1;
+			
+			// aapt resource value: 0
+			public static int MenuItem_android_icon = 0;
+			
+			// aapt resource value: 2
+			public static int MenuItem_android_id = 2;
+			
+			// aapt resource value: 5
+			public static int MenuItem_android_menuCategory = 5;
+			
+			// aapt resource value: 10
+			public static int MenuItem_android_numericShortcut = 10;
+			
+			// aapt resource value: 12
+			public static int MenuItem_android_onClick = 12;
+			
+			// aapt resource value: 6
+			public static int MenuItem_android_orderInCategory = 6;
+			
+			// aapt resource value: 7
+			public static int MenuItem_android_title = 7;
+			
+			// aapt resource value: 8
+			public static int MenuItem_android_titleCondensed = 8;
+			
+			// aapt resource value: 4
+			public static int MenuItem_android_visible = 4;
+			
+			// aapt resource value: 17
+			public static int MenuItem_contentDescription = 17;
+			
+			// aapt resource value: 18
+			public static int MenuItem_iconTint = 18;
+			
+			// aapt resource value: 19
+			public static int MenuItem_iconTintMode = 19;
+			
+			// aapt resource value: 20
+			public static int MenuItem_numericModifiers = 20;
+			
+			// aapt resource value: 21
+			public static int MenuItem_showAsAction = 21;
+			
+			// aapt resource value: 22
+			public static int MenuItem_tooltipText = 22;
+			
+			// aapt resource value: { 0x10100AE,0x101012C,0x101012D,0x101012E,0x101012F,0x1010130,0x1010131,0x7F030142,0x7F030171 }
+			public static int[] MenuView = new int[] {
+					16842926,
+					16843052,
+					16843053,
+					16843054,
+					16843055,
+					16843056,
+					16843057,
+					2130903362,
+					2130903409};
+			
+			// aapt resource value: 4
+			public static int MenuView_android_headerBackground = 4;
+			
+			// aapt resource value: 2
+			public static int MenuView_android_horizontalDivider = 2;
+			
+			// aapt resource value: 5
+			public static int MenuView_android_itemBackground = 5;
+			
+			// aapt resource value: 6
+			public static int MenuView_android_itemIconDisabledAlpha = 6;
+			
+			// aapt resource value: 1
+			public static int MenuView_android_itemTextAppearance = 1;
+			
+			// aapt resource value: 3
+			public static int MenuView_android_verticalDivider = 3;
+			
+			// aapt resource value: 0
+			public static int MenuView_android_windowAnimationStyle = 0;
+			
+			// aapt resource value: 7
+			public static int MenuView_preserveIconSpacing = 7;
+			
+			// aapt resource value: 8
+			public static int MenuView_subMenuArrow = 8;
+			
+			// aapt resource value: { 0x10100D4,0x10100DD,0x101011F,0x7F0300B5,0x7F0300DE,0x7F0300FA,0x7F0300FB,0x7F0300FD,0x7F0300FF,0x7F030102,0x7F030105,0x7F03012B }
+			public static int[] NavigationView = new int[] {
+					16842964,
+					16842973,
+					16843039,
+					2130903221,
+					2130903262,
+					2130903290,
+					2130903291,
+					2130903293,
+					2130903295,
+					2130903298,
+					2130903301,
+					2130903339};
+			
+			// aapt resource value: 0
+			public static int NavigationView_android_background = 0;
+			
+			// aapt resource value: 1
+			public static int NavigationView_android_fitsSystemWindows = 1;
+			
+			// aapt resource value: 2
+			public static int NavigationView_android_maxWidth = 2;
+			
+			// aapt resource value: 3
+			public static int NavigationView_elevation = 3;
+			
+			// aapt resource value: 4
+			public static int NavigationView_headerLayout = 4;
+			
+			// aapt resource value: 5
+			public static int NavigationView_itemBackground = 5;
+			
+			// aapt resource value: 6
+			public static int NavigationView_itemHorizontalPadding = 6;
+			
+			// aapt resource value: 7
+			public static int NavigationView_itemIconPadding = 7;
+			
+			// aapt resource value: 8
+			public static int NavigationView_itemIconTint = 8;
+			
+			// aapt resource value: 9
+			public static int NavigationView_itemTextAppearance = 9;
+			
+			// aapt resource value: 10
+			public static int NavigationView_itemTextColor = 10;
+			
+			// aapt resource value: 11
+			public static int NavigationView_menu = 11;
+			
+			// aapt resource value: { 0x1010176,0x10102C9,0x7F030132 }
+			public static int[] PopupWindow = new int[] {
+					16843126,
+					16843465,
+					2130903346};
+			
+			// aapt resource value: { 0x7F030168 }
+			public static int[] PopupWindowBackgroundState = new int[] {
+					2130903400};
+			
+			// aapt resource value: 0
+			public static int PopupWindowBackgroundState_state_above_anchor = 0;
+			
+			// aapt resource value: 1
+			public static int PopupWindow_android_popupAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public static int PopupWindow_android_popupBackground = 0;
+			
+			// aapt resource value: 2
+			public static int PopupWindow_overlapAnchor = 2;
+			
+			// aapt resource value: { 0x7F030133,0x7F030136 }
+			public static int[] RecycleListView = new int[] {
+					2130903347,
+					2130903350};
+			
+			// aapt resource value: 0
+			public static int RecycleListView_paddingBottomNoButtons = 0;
+			
+			// aapt resource value: 1
+			public static int RecycleListView_paddingTopNoTitle = 1;
+			
+			// aapt resource value: { 0x10100C4,0x10100F1,0x7F0300C9,0x7F0300CA,0x7F0300CB,0x7F0300CC,0x7F0300CD,0x7F03010A,0x7F03014C,0x7F030161,0x7F030167 }
+			public static int[] RecyclerView = new int[] {
+					16842948,
+					16842993,
+					2130903241,
+					2130903242,
+					2130903243,
+					2130903244,
+					2130903245,
+					2130903306,
+					2130903372,
+					2130903393,
+					2130903399};
+			
+			// aapt resource value: 1
+			public static int RecyclerView_android_descendantFocusability = 1;
+			
+			// aapt resource value: 0
+			public static int RecyclerView_android_orientation = 0;
+			
+			// aapt resource value: 2
+			public static int RecyclerView_fastScrollEnabled = 2;
+			
+			// aapt resource value: 3
+			public static int RecyclerView_fastScrollHorizontalThumbDrawable = 3;
+			
+			// aapt resource value: 4
+			public static int RecyclerView_fastScrollHorizontalTrackDrawable = 4;
+			
+			// aapt resource value: 5
+			public static int RecyclerView_fastScrollVerticalThumbDrawable = 5;
+			
+			// aapt resource value: 6
+			public static int RecyclerView_fastScrollVerticalTrackDrawable = 6;
+			
+			// aapt resource value: 7
+			public static int RecyclerView_layoutManager = 7;
+			
+			// aapt resource value: 8
+			public static int RecyclerView_reverseLayout = 8;
+			
+			// aapt resource value: 9
+			public static int RecyclerView_spanCount = 9;
+			
+			// aapt resource value: 10
+			public static int RecyclerView_stackFromEnd = 10;
+			
+			// aapt resource value: { 0x7F0300F8 }
+			public static int[] ScrimInsetsFrameLayout = new int[] {
+					2130903288};
+			
+			// aapt resource value: 0
+			public static int ScrimInsetsFrameLayout_insetForeground = 0;
+			
+			// aapt resource value: { 0x7F03003A }
+			public static int[] ScrollingViewBehavior_Layout = new int[] {
+					2130903098};
+			
+			// aapt resource value: 0
+			public static int ScrollingViewBehavior_Layout_behavior_overlapTop = 0;
+			
+			// aapt resource value: { 0x10100DA,0x101011F,0x1010220,0x1010264,0x7F030077,0x7F03008F,0x7F0300A5,0x7F0300DD,0x7F0300F4,0x7F030109,0x7F030146,0x7F030147,0x7F030151,0x7F030152,0x7F030172,0x7F030177,0x7F0301D2 }
+			public static int[] SearchView = new int[] {
+					16842970,
+					16843039,
+					16843296,
+					16843364,
+					2130903159,
+					2130903183,
+					2130903205,
+					2130903261,
+					2130903284,
+					2130903305,
+					2130903366,
+					2130903367,
+					2130903377,
+					2130903378,
+					2130903410,
+					2130903415,
+					2130903506};
+			
+			// aapt resource value: 0
+			public static int SearchView_android_focusable = 0;
+			
+			// aapt resource value: 3
+			public static int SearchView_android_imeOptions = 3;
+			
+			// aapt resource value: 2
+			public static int SearchView_android_inputType = 2;
+			
+			// aapt resource value: 1
+			public static int SearchView_android_maxWidth = 1;
+			
+			// aapt resource value: 4
+			public static int SearchView_closeIcon = 4;
+			
+			// aapt resource value: 5
+			public static int SearchView_commitIcon = 5;
+			
+			// aapt resource value: 6
+			public static int SearchView_defaultQueryHint = 6;
+			
+			// aapt resource value: 7
+			public static int SearchView_goIcon = 7;
+			
+			// aapt resource value: 8
+			public static int SearchView_iconifiedByDefault = 8;
+			
+			// aapt resource value: 9
+			public static int SearchView_layout = 9;
+			
+			// aapt resource value: 10
+			public static int SearchView_queryBackground = 10;
+			
+			// aapt resource value: 11
+			public static int SearchView_queryHint = 11;
+			
+			// aapt resource value: 12
+			public static int SearchView_searchHintIcon = 12;
+			
+			// aapt resource value: 13
+			public static int SearchView_searchIcon = 13;
+			
+			// aapt resource value: 14
+			public static int SearchView_submitBackground = 14;
+			
+			// aapt resource value: 15
+			public static int SearchView_suggestionRowLayout = 15;
+			
+			// aapt resource value: 16
+			public static int SearchView_voiceIcon = 16;
+			
+			// aapt resource value: { 0x7F03015F,0x7F030160 }
+			public static int[] Snackbar = new int[] {
+					2130903391,
+					2130903392};
+			
+			// aapt resource value: { 0x101011F,0x7F0300B5,0x7F030127 }
+			public static int[] SnackbarLayout = new int[] {
+					16843039,
+					2130903221,
+					2130903335};
+			
+			// aapt resource value: 0
+			public static int SnackbarLayout_android_maxWidth = 0;
+			
+			// aapt resource value: 1
+			public static int SnackbarLayout_elevation = 1;
+			
+			// aapt resource value: 2
+			public static int SnackbarLayout_maxActionInlineWidth = 2;
+			
+			// aapt resource value: 0
+			public static int Snackbar_snackbarButtonStyle = 0;
+			
+			// aapt resource value: 1
+			public static int Snackbar_snackbarStyle = 1;
+			
+			// aapt resource value: { 0x10100B2,0x1010176,0x101017B,0x1010262,0x7F030140 }
+			public static int[] Spinner = new int[] {
+					16842930,
+					16843126,
+					16843131,
+					16843362,
+					2130903360};
+			
+			// aapt resource value: 3
+			public static int Spinner_android_dropDownWidth = 3;
+			
+			// aapt resource value: 0
+			public static int Spinner_android_entries = 0;
+			
+			// aapt resource value: 1
+			public static int Spinner_android_popupBackground = 1;
+			
+			// aapt resource value: 2
+			public static int Spinner_android_prompt = 2;
+			
+			// aapt resource value: 4
+			public static int Spinner_popupTheme = 4;
+			
+			// aapt resource value: { 0x101011C,0x1010194,0x1010195,0x1010196,0x101030C,0x101030D }
+			public static int[] StateListDrawable = new int[] {
+					16843036,
+					16843156,
+					16843157,
+					16843158,
+					16843532,
+					16843533};
+			
+			// aapt resource value: { 0x1010199 }
+			public static int[] StateListDrawableItem = new int[] {
+					16843161};
+			
+			// aapt resource value: 0
+			public static int StateListDrawableItem_android_drawable = 0;
+			
+			// aapt resource value: 3
+			public static int StateListDrawable_android_constantSize = 3;
+			
+			// aapt resource value: 0
+			public static int StateListDrawable_android_dither = 0;
+			
+			// aapt resource value: 4
+			public static int StateListDrawable_android_enterFadeDuration = 4;
+			
+			// aapt resource value: 5
+			public static int StateListDrawable_android_exitFadeDuration = 5;
+			
+			// aapt resource value: 2
+			public static int StateListDrawable_android_variablePadding = 2;
+			
+			// aapt resource value: 1
+			public static int StateListDrawable_android_visible = 1;
+			
+			// aapt resource value: { 0x1010124,0x1010125,0x1010142,0x7F03015A,0x7F030165,0x7F030178,0x7F030179,0x7F03017B,0x7F0301B3,0x7F0301B4,0x7F0301B5,0x7F0301CC,0x7F0301CD,0x7F0301CE }
+			public static int[] SwitchCompat = new int[] {
+					16843044,
+					16843045,
+					16843074,
+					2130903386,
+					2130903397,
+					2130903416,
+					2130903417,
+					2130903419,
+					2130903475,
+					2130903476,
+					2130903477,
+					2130903500,
+					2130903501,
+					2130903502};
+			
+			// aapt resource value: 1
+			public static int SwitchCompat_android_textOff = 1;
+			
+			// aapt resource value: 0
+			public static int SwitchCompat_android_textOn = 0;
+			
+			// aapt resource value: 2
+			public static int SwitchCompat_android_thumb = 2;
+			
+			// aapt resource value: 3
+			public static int SwitchCompat_showText = 3;
+			
+			// aapt resource value: 4
+			public static int SwitchCompat_splitTrack = 4;
+			
+			// aapt resource value: 5
+			public static int SwitchCompat_switchMinWidth = 5;
+			
+			// aapt resource value: 6
+			public static int SwitchCompat_switchPadding = 6;
+			
+			// aapt resource value: 7
+			public static int SwitchCompat_switchTextAppearance = 7;
+			
+			// aapt resource value: 8
+			public static int SwitchCompat_thumbTextPadding = 8;
+			
+			// aapt resource value: 9
+			public static int SwitchCompat_thumbTint = 9;
+			
+			// aapt resource value: 10
+			public static int SwitchCompat_thumbTintMode = 10;
+			
+			// aapt resource value: 11
+			public static int SwitchCompat_track = 11;
+			
+			// aapt resource value: 12
+			public static int SwitchCompat_trackTint = 12;
+			
+			// aapt resource value: 13
+			public static int SwitchCompat_trackTintMode = 13;
+			
+			// aapt resource value: { 0x1010002,0x10100F2,0x101014F }
+			public static int[] TabItem = new int[] {
+					16842754,
+					16842994,
+					16843087};
+			
+			// aapt resource value: 0
+			public static int TabItem_android_icon = 0;
+			
+			// aapt resource value: 1
+			public static int TabItem_android_layout = 1;
+			
+			// aapt resource value: 2
+			public static int TabItem_android_text = 2;
+			
+			// aapt resource value: { 0x7F03017C,0x7F03017D,0x7F03017E,0x7F03017F,0x7F030180,0x7F030181,0x7F030182,0x7F030183,0x7F030184,0x7F030185,0x7F030186,0x7F030187,0x7F030188,0x7F030189,0x7F03018A,0x7F03018B,0x7F03018C,0x7F03018D,0x7F03018E,0x7F03018F,0x7F030190,0x7F030191,0x7F030193,0x7F030194,0x7F030195 }
+			public static int[] TabLayout = new int[] {
+					2130903420,
+					2130903421,
+					2130903422,
+					2130903423,
+					2130903424,
+					2130903425,
+					2130903426,
+					2130903427,
+					2130903428,
+					2130903429,
+					2130903430,
+					2130903431,
+					2130903432,
+					2130903433,
+					2130903434,
+					2130903435,
+					2130903436,
+					2130903437,
+					2130903438,
+					2130903439,
+					2130903440,
+					2130903441,
+					2130903443,
+					2130903444,
+					2130903445};
+			
+			// aapt resource value: 0
+			public static int TabLayout_tabBackground = 0;
+			
+			// aapt resource value: 1
+			public static int TabLayout_tabContentStart = 1;
+			
+			// aapt resource value: 2
+			public static int TabLayout_tabGravity = 2;
+			
+			// aapt resource value: 3
+			public static int TabLayout_tabIconTint = 3;
+			
+			// aapt resource value: 4
+			public static int TabLayout_tabIconTintMode = 4;
+			
+			// aapt resource value: 5
+			public static int TabLayout_tabIndicator = 5;
+			
+			// aapt resource value: 6
+			public static int TabLayout_tabIndicatorAnimationDuration = 6;
+			
+			// aapt resource value: 7
+			public static int TabLayout_tabIndicatorColor = 7;
+			
+			// aapt resource value: 8
+			public static int TabLayout_tabIndicatorFullWidth = 8;
+			
+			// aapt resource value: 9
+			public static int TabLayout_tabIndicatorGravity = 9;
+			
+			// aapt resource value: 10
+			public static int TabLayout_tabIndicatorHeight = 10;
+			
+			// aapt resource value: 11
+			public static int TabLayout_tabInlineLabel = 11;
+			
+			// aapt resource value: 12
+			public static int TabLayout_tabMaxWidth = 12;
+			
+			// aapt resource value: 13
+			public static int TabLayout_tabMinWidth = 13;
+			
+			// aapt resource value: 14
+			public static int TabLayout_tabMode = 14;
+			
+			// aapt resource value: 15
+			public static int TabLayout_tabPadding = 15;
+			
+			// aapt resource value: 16
+			public static int TabLayout_tabPaddingBottom = 16;
+			
+			// aapt resource value: 17
+			public static int TabLayout_tabPaddingEnd = 17;
+			
+			// aapt resource value: 18
+			public static int TabLayout_tabPaddingStart = 18;
+			
+			// aapt resource value: 19
+			public static int TabLayout_tabPaddingTop = 19;
+			
+			// aapt resource value: 20
+			public static int TabLayout_tabRippleColor = 20;
+			
+			// aapt resource value: 21
+			public static int TabLayout_tabSelectedTextColor = 21;
+			
+			// aapt resource value: 22
+			public static int TabLayout_tabTextAppearance = 22;
+			
+			// aapt resource value: 23
+			public static int TabLayout_tabTextColor = 23;
+			
+			// aapt resource value: 24
+			public static int TabLayout_tabUnboundedRipple = 24;
+			
+			// aapt resource value: { 0x1010095,0x1010096,0x1010097,0x1010098,0x101009A,0x101009B,0x1010161,0x1010162,0x1010163,0x1010164,0x10103AC,0x7F0300D1,0x7F030196 }
+			public static int[] TextAppearance = new int[] {
+					16842901,
+					16842902,
+					16842903,
+					16842904,
+					16842906,
+					16842907,
+					16843105,
+					16843106,
+					16843107,
+					16843108,
+					16843692,
+					2130903249,
+					2130903446};
+			
+			// aapt resource value: 10
+			public static int TextAppearance_android_fontFamily = 10;
+			
+			// aapt resource value: 6
+			public static int TextAppearance_android_shadowColor = 6;
+			
+			// aapt resource value: 7
+			public static int TextAppearance_android_shadowDx = 7;
+			
+			// aapt resource value: 8
+			public static int TextAppearance_android_shadowDy = 8;
+			
+			// aapt resource value: 9
+			public static int TextAppearance_android_shadowRadius = 9;
+			
+			// aapt resource value: 3
+			public static int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 4
+			public static int TextAppearance_android_textColorHint = 4;
+			
+			// aapt resource value: 5
+			public static int TextAppearance_android_textColorLink = 5;
+			
+			// aapt resource value: 0
+			public static int TextAppearance_android_textSize = 0;
+			
+			// aapt resource value: 2
+			public static int TextAppearance_android_textStyle = 2;
+			
+			// aapt resource value: 1
+			public static int TextAppearance_android_typeface = 1;
+			
+			// aapt resource value: 11
+			public static int TextAppearance_fontFamily = 11;
+			
+			// aapt resource value: 12
+			public static int TextAppearance_textAllCaps = 12;
+			
+			// aapt resource value: { 0x101009A,0x1010150,0x7F030043,0x7F030044,0x7F030045,0x7F030046,0x7F030047,0x7F030048,0x7F030049,0x7F03004A,0x7F03004B,0x7F0300A0,0x7F0300A1,0x7F0300A2,0x7F0300A3,0x7F0300B8,0x7F0300B9,0x7F0300E0,0x7F0300E1,0x7F0300E2,0x7F0300E6,0x7F0300E7,0x7F0300E8,0x7F03013A,0x7F03013B,0x7F03013C,0x7F03013D,0x7F03013E }
+			public static int[] TextInputLayout = new int[] {
+					16842906,
+					16843088,
+					2130903107,
+					2130903108,
+					2130903109,
+					2130903110,
+					2130903111,
+					2130903112,
+					2130903113,
+					2130903114,
+					2130903115,
+					2130903200,
+					2130903201,
+					2130903202,
+					2130903203,
+					2130903224,
+					2130903225,
+					2130903264,
+					2130903265,
+					2130903266,
+					2130903270,
+					2130903271,
+					2130903272,
+					2130903354,
+					2130903355,
+					2130903356,
+					2130903357,
+					2130903358};
+			
+			// aapt resource value: 1
+			public static int TextInputLayout_android_hint = 1;
+			
+			// aapt resource value: 0
+			public static int TextInputLayout_android_textColorHint = 0;
+			
+			// aapt resource value: 2
+			public static int TextInputLayout_boxBackgroundColor = 2;
+			
+			// aapt resource value: 3
+			public static int TextInputLayout_boxBackgroundMode = 3;
+			
+			// aapt resource value: 4
+			public static int TextInputLayout_boxCollapsedPaddingTop = 4;
+			
+			// aapt resource value: 5
+			public static int TextInputLayout_boxCornerRadiusBottomEnd = 5;
+			
+			// aapt resource value: 6
+			public static int TextInputLayout_boxCornerRadiusBottomStart = 6;
+			
+			// aapt resource value: 7
+			public static int TextInputLayout_boxCornerRadiusTopEnd = 7;
+			
+			// aapt resource value: 8
+			public static int TextInputLayout_boxCornerRadiusTopStart = 8;
+			
+			// aapt resource value: 9
+			public static int TextInputLayout_boxStrokeColor = 9;
+			
+			// aapt resource value: 10
+			public static int TextInputLayout_boxStrokeWidth = 10;
+			
+			// aapt resource value: 11
+			public static int TextInputLayout_counterEnabled = 11;
+			
+			// aapt resource value: 12
+			public static int TextInputLayout_counterMaxLength = 12;
+			
+			// aapt resource value: 13
+			public static int TextInputLayout_counterOverflowTextAppearance = 13;
+			
+			// aapt resource value: 14
+			public static int TextInputLayout_counterTextAppearance = 14;
+			
+			// aapt resource value: 15
+			public static int TextInputLayout_errorEnabled = 15;
+			
+			// aapt resource value: 16
+			public static int TextInputLayout_errorTextAppearance = 16;
+			
+			// aapt resource value: 17
+			public static int TextInputLayout_helperText = 17;
+			
+			// aapt resource value: 18
+			public static int TextInputLayout_helperTextEnabled = 18;
+			
+			// aapt resource value: 19
+			public static int TextInputLayout_helperTextTextAppearance = 19;
+			
+			// aapt resource value: 20
+			public static int TextInputLayout_hintAnimationEnabled = 20;
+			
+			// aapt resource value: 21
+			public static int TextInputLayout_hintEnabled = 21;
+			
+			// aapt resource value: 22
+			public static int TextInputLayout_hintTextAppearance = 22;
+			
+			// aapt resource value: 23
+			public static int TextInputLayout_passwordToggleContentDescription = 23;
+			
+			// aapt resource value: 24
+			public static int TextInputLayout_passwordToggleDrawable = 24;
+			
+			// aapt resource value: 25
+			public static int TextInputLayout_passwordToggleEnabled = 25;
+			
+			// aapt resource value: 26
+			public static int TextInputLayout_passwordToggleTint = 26;
+			
+			// aapt resource value: 27
+			public static int TextInputLayout_passwordToggleTintMode = 27;
+			
+			// aapt resource value: { 0x1010034,0x7F0300B6,0x7F0300B7 }
+			public static int[] ThemeEnforcement = new int[] {
+					16842804,
+					2130903222,
+					2130903223};
+			
+			// aapt resource value: 0
+			public static int ThemeEnforcement_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public static int ThemeEnforcement_enforceMaterialTheme = 1;
+			
+			// aapt resource value: 2
+			public static int ThemeEnforcement_enforceTextAppearance = 2;
+			
+			// aapt resource value: { 0x10100AF,0x1010140,0x7F030051,0x7F03007F,0x7F030080,0x7F030091,0x7F030092,0x7F030093,0x7F030094,0x7F030095,0x7F030096,0x7F030123,0x7F030124,0x7F030128,0x7F03012D,0x7F03012E,0x7F030140,0x7F030173,0x7F030174,0x7F030175,0x7F0301BB,0x7F0301BD,0x7F0301BE,0x7F0301BF,0x7F0301C0,0x7F0301C1,0x7F0301C2,0x7F0301C3,0x7F0301C4 }
+			public static int[] Toolbar = new int[] {
+					16842927,
+					16843072,
+					2130903121,
+					2130903167,
+					2130903168,
+					2130903185,
+					2130903186,
+					2130903187,
+					2130903188,
+					2130903189,
+					2130903190,
+					2130903331,
+					2130903332,
+					2130903336,
+					2130903341,
+					2130903342,
+					2130903360,
+					2130903411,
+					2130903412,
+					2130903413,
+					2130903483,
+					2130903485,
+					2130903486,
+					2130903487,
+					2130903488,
+					2130903489,
+					2130903490,
+					2130903491,
+					2130903492};
+			
+			// aapt resource value: 0
+			public static int Toolbar_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public static int Toolbar_android_minHeight = 1;
+			
+			// aapt resource value: 2
+			public static int Toolbar_buttonGravity = 2;
+			
+			// aapt resource value: 3
+			public static int Toolbar_collapseContentDescription = 3;
+			
+			// aapt resource value: 4
+			public static int Toolbar_collapseIcon = 4;
+			
+			// aapt resource value: 5
+			public static int Toolbar_contentInsetEnd = 5;
+			
+			// aapt resource value: 6
+			public static int Toolbar_contentInsetEndWithActions = 6;
+			
+			// aapt resource value: 7
+			public static int Toolbar_contentInsetLeft = 7;
+			
+			// aapt resource value: 8
+			public static int Toolbar_contentInsetRight = 8;
+			
+			// aapt resource value: 9
+			public static int Toolbar_contentInsetStart = 9;
+			
+			// aapt resource value: 10
+			public static int Toolbar_contentInsetStartWithNavigation = 10;
+			
+			// aapt resource value: 11
+			public static int Toolbar_logo = 11;
+			
+			// aapt resource value: 12
+			public static int Toolbar_logoDescription = 12;
+			
+			// aapt resource value: 13
+			public static int Toolbar_maxButtonHeight = 13;
+			
+			// aapt resource value: 14
+			public static int Toolbar_navigationContentDescription = 14;
+			
+			// aapt resource value: 15
+			public static int Toolbar_navigationIcon = 15;
+			
+			// aapt resource value: 16
+			public static int Toolbar_popupTheme = 16;
+			
+			// aapt resource value: 17
+			public static int Toolbar_subtitle = 17;
+			
+			// aapt resource value: 18
+			public static int Toolbar_subtitleTextAppearance = 18;
+			
+			// aapt resource value: 19
+			public static int Toolbar_subtitleTextColor = 19;
+			
+			// aapt resource value: 20
+			public static int Toolbar_title = 20;
+			
+			// aapt resource value: 21
+			public static int Toolbar_titleMargin = 21;
+			
+			// aapt resource value: 22
+			public static int Toolbar_titleMarginBottom = 22;
+			
+			// aapt resource value: 23
+			public static int Toolbar_titleMarginEnd = 23;
+			
+			// aapt resource value: 26
+			public static int Toolbar_titleMargins = 26;
+			
+			// aapt resource value: 24
+			public static int Toolbar_titleMarginStart = 24;
+			
+			// aapt resource value: 25
+			public static int Toolbar_titleMarginTop = 25;
+			
+			// aapt resource value: 27
+			public static int Toolbar_titleTextAppearance = 27;
+			
+			// aapt resource value: 28
+			public static int Toolbar_titleTextColor = 28;
+			
+			// aapt resource value: { 0x1010000,0x10100DA,0x7F030134,0x7F030135,0x7F0301B1 }
+			public static int[] View = new int[] {
+					16842752,
+					16842970,
+					2130903348,
+					2130903349,
+					2130903473};
+			
+			// aapt resource value: { 0x10100D4,0x7F030034,0x7F030035 }
+			public static int[] ViewBackgroundHelper = new int[] {
+					16842964,
+					2130903092,
+					2130903093};
+			
+			// aapt resource value: 0
+			public static int ViewBackgroundHelper_android_background = 0;
+			
+			// aapt resource value: 1
+			public static int ViewBackgroundHelper_backgroundTint = 1;
+			
+			// aapt resource value: 2
+			public static int ViewBackgroundHelper_backgroundTintMode = 2;
+			
+			// aapt resource value: { 0x10100D0,0x10100F2,0x10100F3 }
+			public static int[] ViewStubCompat = new int[] {
+					16842960,
+					16842994,
+					16842995};
+			
+			// aapt resource value: 0
+			public static int ViewStubCompat_android_id = 0;
+			
+			// aapt resource value: 2
+			public static int ViewStubCompat_android_inflatedId = 2;
+			
+			// aapt resource value: 1
+			public static int ViewStubCompat_android_layout = 1;
+			
+			// aapt resource value: 1
+			public static int View_android_focusable = 1;
+			
+			// aapt resource value: 0
+			public static int View_android_theme = 0;
+			
+			// aapt resource value: 2
+			public static int View_paddingEnd = 2;
+			
+			// aapt resource value: 3
+			public static int View_paddingStart = 3;
+			
+			// aapt resource value: 4
+			public static int View_theme = 4;
 			
 			static Styleable()
 			{
@@ -1179,31 +8618,6 @@ namespace AirshipBindings.NETStandard
 			}
 			
 			private Styleable()
-			{
-			}
-		}
-		
-		public partial class Xml
-		{
-			
-			// aapt resource value: 0x7F0F0000
-			public static int ua_default_actions = 2131689472;
-			
-			// aapt resource value: 0x7F0F0001
-			public static int ua_default_channels = 2131689473;
-			
-			// aapt resource value: 0x7F0F0003
-			public static int ua_notification_buttons = 2131689475;
-			
-			// aapt resource value: 0x7F0F0002
-			public static int ua_notification_button_overrides = 2131689474;
-			
-			static Xml()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Xml()
 			{
 			}
 		}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/packages.config
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/packages.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Android.Arch.Core.Common" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Core.Runtime" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Common" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.LiveData" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.LiveData.Core" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.Runtime" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Arch.Lifecycle.ViewModel" version="1.1.1.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Annotations" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.AsyncLayoutInflater" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Collections" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Compat" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CoordinaterLayout" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Core.UI" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Core.Utils" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CursorAdapter" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CustomTabs" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.CustomView" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Design" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.DocumentFile" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.DrawerLayout" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Fragment" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Interpolator" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Loader" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.LocalBroadcastManager" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Media.Compat" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Print" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.SlidingPaneLayout" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.SwipeRefreshLayout" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Transition" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v4" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.3" targetFramework="monoandroid90" />
+  <package id="Xamarin.Forms" version="4.6.0.726" targetFramework="monoandroid90" requireReinstallation="true" />
+</packages>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/AirshipBindings.NETStandard.iOS.csproj
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/AirshipBindings.NETStandard.iOS.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.Forms.4.5.0.657\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.4.5.0.657\build\Xamarin.Forms.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -47,6 +48,15 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.4.5.0.657\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.4.5.0.657\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.4.5.0.657\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -57,6 +67,8 @@
     <Compile Include="..\..\SharedAssemblyInfo.CrossPlatform.cs">
       <Link>Properties\SharedAssemblyInfo.CrossPlatform.cs</Link>
     </Compile>
+    <Compile Include="MessagePageRenderer.cs" />
+    <Compile Include="AirshipForms.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.NETStandard.Abstractions\AirshipBindings.NETStandard.Abstractions.csproj">
@@ -80,5 +92,9 @@
       <Name>AirshipBindings.iOS.MessageCenter</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.4.5.0.657\build\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.4.5.0.657\build\Xamarin.Forms.targets')" />
 </Project>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/AirshipForms.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/AirshipForms.cs
@@ -1,0 +1,18 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+namespace UrbanAirship.NETStandard
+{
+    /// <summary>
+    /// Entry point for initializing Airship Forms controls.
+    /// </summary>
+    public class AirshipForms
+    {
+        /// <summary>
+        /// Initializes Airship Forms controls.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/MessagePageRenderer.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/MessagePageRenderer.cs
@@ -1,0 +1,145 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+using System;
+using Foundation;
+using UIKit;
+using UrbanAirship.NETStandard.MessageCenter;
+using WebKit;
+using Xamarin.Forms.Platform.iOS;
+
+namespace UrbanAirship.NETStandard.iOS
+{
+    public class MessagePageRenderer : PageRenderer, IWKNavigationDelegate, IUANativeBridgeDelegate
+    {
+        private UAWebView webView;
+        private UANativeBridge nativeBridge;
+        private MessagePage messagePage;
+        private string messageId;
+
+        public MessagePageRenderer()
+        {
+            webView = new UAWebView();
+            nativeBridge = UANativeBridge.NativeBridge();
+            webView.NavigationDelegate = nativeBridge;
+            nativeBridge.ForwardNavigationDelegate = this;
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            webView.Frame = UIScreen.MainScreen.Bounds;
+            webView.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+            webView.TranslatesAutoresizingMaskIntoConstraints = true;
+
+            View.AddSubview(webView);
+        }
+
+        public void LoadMessage(string messageId)
+        {
+            var message = UAMessageCenter.Shared().MessageList.Message(messageId);
+            if (message != null)
+            {
+                LoadMessageBody(message);
+            }
+            else
+            {
+                UAMessageCenter.Shared().MessageList.RetrieveMessageList(() =>
+                {
+                    message = UAMessageCenter.Shared().MessageList.Message(messageId);
+                    if (message != null && !message.IsExpired())
+                    {
+                        LoadMessageBody(message);
+                    }
+                    else
+                    {
+                        messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
+                    }
+                }, () =>
+                {
+                    messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.FetchFailed);
+                });
+            }
+        }
+
+        public void Close()
+        {
+            messagePage.OnRendererClosed(messageId);
+        }
+
+        [Export("webView:decidePolicyForNavigationResponse:decisionHandler:")]
+        public void DecidePolicy(WKWebView webView, WKNavigationResponse navigationResponse, Action<WKNavigationResponsePolicy> decisionHandler)
+        {
+            var response = navigationResponse.Response as NSHttpUrlResponse;
+            if (response.StatusCode >= 400 && response.StatusCode <= 599)
+            {
+                decisionHandler(WKNavigationResponsePolicy.Cancel);
+                if (response.StatusCode == 410)
+                {
+                    messagePage.OnRendererLoadFailed(messageId, false, MessageFailureStatus.Unavailable);
+                }
+                else
+                {
+                    messagePage.OnRendererLoadFailed(messageId, true, MessageFailureStatus.LoadFailed);
+                }
+            }
+            else
+            {
+                decisionHandler(WKNavigationResponsePolicy.Allow);
+            }
+        }
+
+        [Export("webView:didFinishNavigation:")]
+        public void DidFinishNavigation(WKWebView webView, WKNavigation navigation)
+        {
+            messagePage.OnRendererLoaded(messageId);
+        }
+
+        [Export("webView:didFailNavigation:withError:")]
+        public void DidFailNavigation(WKWebView webView, WKNavigation navigation, NSError error)
+        {
+            messagePage.OnRendererLoadFailed(messageId, true, MessageFailureStatus.LoadFailed);
+        }
+
+        [Export("webView:didFailProvisionalNavigation:withError:")]
+        public void DidFailProvisionalNavigation(WKWebView webView, WKNavigation navigation, NSError error)
+        {
+            webView.NavigationDelegate?.DidFailNavigation(webView, navigation, error);
+        }
+
+        protected override void OnElementChanged(VisualElementChangedEventArgs e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null || Element == null)
+            {
+                return;
+            }
+
+            messagePage = e.NewElement as MessagePage;
+            messageId = messagePage.MessageId;
+
+            if (messageId != null)
+            {
+                LoadMessage(messageId);
+            }
+        }
+
+        private void LoadMessageBody(UAInboxMessage message)
+        {
+            var request = new NSMutableUrlRequest(message.MessageBodyURL);
+            UAMessageCenter.Shared().User.GetUserData((UAUserData userData) =>
+            {
+                var auth = UAUtils.AuthHeaderString(userData.Username, userData.Password);
+
+                NSMutableDictionary dict = new NSMutableDictionary();
+                dict.Add(new NSString("Authorization"), new NSString(auth));
+                request.Headers = dict;
+
+                webView.LoadRequest(request);
+            });
+        }
+    }
+}

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/MessagePageRenderer.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/MessagePageRenderer.cs
@@ -3,6 +3,7 @@
 */
 
 using System;
+using System.ComponentModel;
 using Foundation;
 using UIKit;
 using UrbanAirship.NETStandard.MessageCenter;
@@ -120,11 +121,24 @@ namespace UrbanAirship.NETStandard.iOS
 
             messagePage = e.NewElement as MessagePage;
             messageId = messagePage.MessageId;
+            messagePage.PropertyChanged += OnElementPropertyChanged;
 
             if (messageId != null)
             {
                 LoadMessage(messageId);
             }
+        }
+
+        private void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+           if (e.PropertyName.Equals(MessagePage.MessageIdProperty.PropertyName))
+           {
+                messageId = messagePage.MessageId;
+                if (messageId != null)
+                {
+                    LoadMessage(messageId);
+                }
+           }
         }
 
         private void LoadMessageBody(UAInboxMessage message)
@@ -139,6 +153,8 @@ namespace UrbanAirship.NETStandard.iOS
                 request.Headers = dict;
 
                 webView.LoadRequest(request);
+
+                messagePage.OnRendererLoadStarted(messageId);
             });
         }
     }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Properties/AssemblyInfo.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Properties/AssemblyInfo.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
 using Foundation;
+using UrbanAirship.NETStandard.MessageCenter;
+using Xamarin.Forms;
+
+[assembly: AssemblyTitle("AirshipBindings")]
+
+[assembly: ExportRenderer(typeof(MessagePage), typeof(UrbanAirship.NETStandard.iOS.MessagePageRenderer))]
 
 // This attribute allows you to mark your assemblies as “safe to link”.
 // When the attribute is present, the linker—if enabled—will process the assembly
 // even if you’re using the “Link SDK assemblies only” option, which is the default for device builds.
-
-[assembly: AssemblyTitle("AirshipBindings")]
-
 [assembly: LinkerSafe]
-

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/packages.config
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="4.5.0.657" targetFramework="xamarinios10" />
+</packages>

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/AirshipBindings.NETStandard.csproj
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/AirshipBindings.NETStandard.csproj
@@ -16,4 +16,7 @@
       <Link>Properties\SharedAssemblyInfo.CrossPlatform.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds a Forms control deriving from `ContentPage` that allows easy loading of message center messages in a cross platform app. ContentPages in Forms are analogous to view controllers, and literally descend from `UIViewController` on iOS.

One of the consequences of this is that our NETStandard library will now have an explicit dependency on Xamarin.Forms for the first time. We also don't currently have NETStandard bindings for anything message center related, such as fetching and access to the message list, so that will need to be done in another ticket if this is going to be useful to anyone.

Here's an example of how to use it

```               
var messagePage = new MessagePage();

// Load the message
messagePage.MessageId = "SOME_MESSAGE_ID";

// Sign up for events
messagePage.Loaded += (object obj, MessageLoadedEventArgs ea) =>
{
    // Do something
};

messagePage.LoadFailed += (object obj, MessageLoadFailedEventArgs ea) =>
{
    // Do something
};

messagePage.Closed += (object obj, MessageClosedEventArgs ea) =>
{
    // Do something
};

// Push it onto a navigation stack (or whatever)
await Navigation.PushAsync(messagePage);
```

Doing this cross platform means creating a custom `PageRenderer` for both iOS an Android, which handles the platform-specific stuff without the MessagePage class having to know anything about it. The renderer is bound to the page using assembly annotations, and there are subtle challenges for iOS when doing that in a DLL, which I'll explain more about in the diff.

Tested in ad ad-hoc forms app on both platforms, with messages containing action buttons, to verify the native bridge is working correctly.

![Simulator Screen Shot - iPhone 11 - 2020-05-05 at 16 04 59](https://user-images.githubusercontent.com/545958/81125749-f3fc1a00-8eed-11ea-8678-16ae639bdb6c.png)

![Screenshot_1588719883](https://user-images.githubusercontent.com/545958/81125772-fe1e1880-8eed-11ea-9d9f-99227153e8ad.png)
