### PR TITLE
Add the deep link event listener definition

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -170,5 +170,24 @@ namespace UrbanAirship.NETStandard
         {
             throw new NotImplementedException(BaitWithoutSwitchMessage);
         }
+
+        /// <summary>
+        /// Add/remove the deep link event listener.
+        /// </summary>
+        /// <value>The deep link event listener.</value>
+        public delegate void DeepLinkHandler(string deepLink);
+
+        public event DeepLinkHandler OnDeepLinkReceived
+        {
+            add
+            {
+                throw new NotImplementedException(BaitWithoutSwitchMessage);
+            }
+
+            remove
+            {
+                throw new NotImplementedException(BaitWithoutSwitchMessage);
+            }
+        }
     }
 }


### PR DESCRIPTION
The definition was missing [here](https://github.com/urbanairship/urbanairship-xamarin/pull/142).
(my bad 😭)
and thanks to @rlepinski for noticing.