### PR TITLE
[MOBILE-1559] Add data collection properties

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -14,6 +14,16 @@ namespace UrbanAirship.NETStandard
             get; set;
         }
 
+        bool DataCollectionEnabled
+        {
+            get; set;
+        }
+
+        bool PushTokenRegistrationEnabled
+        {
+            get; set;
+        }
+
         IEnumerable<string> Tags
         {
             get;

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -38,6 +38,32 @@ namespace UrbanAirship.NETStandard
             }
         }
 
+        public bool DataCollectionEnabled
+        {
+            get
+            {
+                return UAirship.Shared().DataCollectionEnabled;
+            }
+
+            set
+            {
+                UAirship.Shared().DataCollectionEnabled = value;
+            }
+        }
+
+        public bool PushTokenRegistrationEnabled
+        {
+            get
+            {
+                return UAirship.Shared().PushManager.PushTokenRegistrationEnabled;
+            }
+
+            set
+            {
+                UAirship.Shared().PushManager.PushTokenRegistrationEnabled = value;
+            }
+        }
+
         public IEnumerable<string> Tags
         {
             get

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -37,6 +37,32 @@ namespace UrbanAirship.NETStandard
             }
         }
 
+        public bool DataCollectionEnabled
+        {
+            get
+            {
+                return UAirship.Shared().DataCollectionEnabled;
+            }
+
+            set
+            {
+                UAirship.Shared().DataCollectionEnabled = value;
+            }
+        }
+
+        public bool PushTokenRegistrationEnabled
+        {
+            get
+            {
+                return UAirship.Push().PushTokenRegistrationEnabled;
+            }
+
+            set
+            {
+                UAirship.Push().PushTokenRegistrationEnabled = value;
+            }
+        }
+
         public IEnumerable<string> Tags
         {
             get

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -36,6 +36,26 @@ namespace UrbanAirship.NETStandard
         }
 
         /// <summary>
+        /// Indicates whether data collection is enabled.
+        /// </summary>
+        /// <value><c>true</c> if data collection is enabled; otherwise, <c>false</c>.</value>
+        public bool DataCollectionEnabled
+        {
+            get { throw new NotImplementedException(BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(BaitWithoutSwitchMessage); }
+        }
+
+        /// <summary>
+        /// Indicates whether push token registration is enabled.
+        /// </summary>
+        /// <value><c>true</c> if push token registration is enabled; otherwise, <c>false</c>.</value>
+        public bool PushTokenRegistrationEnabled
+        {
+            get { throw new NotImplementedException(BaitWithoutSwitchMessage); }
+            set { throw new NotImplementedException(BaitWithoutSwitchMessage); }
+        }
+
+        /// <summary>
         /// Gets the tags currently set for the device.
         /// </summary>
         /// <value>The tags.</value>


### PR DESCRIPTION
What do these changes do?
This PR adds data collection properties (data collection and push token registration) to the NetStandard lib.

Why are these changes necessary?
To support data collection feature on Xamarin.

How did you verify these changes?
Via sample app.