### PR TITLE
[MOBILE-1561] Add EditNamedUserAttributes method

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -69,5 +69,7 @@ namespace UrbanAirship.NETStandard
         Channel.TagGroupsEditor EditChannelTagGroups();
         
         Attributes.AttributeEditor EditAttributes();
+
+        Attributes.AttributeEditor EditNamedUserAttributes();
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -70,6 +70,8 @@ namespace UrbanAirship.NETStandard
         
         Attributes.AttributeEditor EditAttributes();
 
+        Attributes.AttributeEditor EditChannelAttributes();
+
         Attributes.AttributeEditor EditNamedUserAttributes();
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -296,7 +296,7 @@ namespace UrbanAirship.NETStandard
             });
         }
 
-        private void ApplyAttributesOperations(AttributeEditor editor, List<AttributeEditor.IAttributeOperation> operations)
+        private void ApplyAttributesOperations(UrbanAirship.Channel.AttributeEditor editor, List<AttributeEditor.IAttributeOperation> operations)
         {
             foreach (var operation in operations)
             {

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -273,6 +273,11 @@ namespace UrbanAirship.NETStandard
 
         public AttributeEditor EditAttributes()
         {
+            return EditChannelAttributes();
+        }
+
+        public AttributeEditor EditChannelAttributes()
+        {
             return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
             {
                 var editor = UAirship.Shared().Channel.EditAttributes();

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -276,42 +276,55 @@ namespace UrbanAirship.NETStandard
             return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
             {
                 var editor = UAirship.Shared().Channel.EditAttributes();
-
-                foreach (var operation in operations)
-                {
-                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
-                    {
-                        editor.SetAttribute(stringOperation.key, stringOperation.value);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
-                    {
-                        editor.SetAttribute(intOperation.key, intOperation.value);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
-                    {
-                        editor.SetAttribute(longOperation.key, longOperation.value);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
-                    {
-                        editor.SetAttribute(floatOperation.key, floatOperation.value);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
-                    {
-                        editor.SetAttribute(doubleOperation.key, doubleOperation.value);
-                    }
-
-                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
-                    {
-                        editor.RemoveAttribute(removeOperation.key);
-                    }
-                }
-
+                ApplyAttributesOperations(editor, operations);
                 editor.Apply();
             });
+        }
+
+        public AttributeEditor EditNamedUserAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var editor = UAirship.Shared().NamedUser.EditAttributes();
+                ApplyAttributesOperations(editor, operations);
+                editor.Apply();
+            });
+        }
+
+        private void ApplyAttributesOperations(AttributeEditor editor, List<AttributeEditor.IAttributeOperation> operations)
+        {
+            foreach (var operation in operations)
+            {
+                if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                {
+                    editor.SetAttribute(stringOperation.key, stringOperation.value);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                {
+                    editor.SetAttribute(intOperation.key, intOperation.value);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                {
+                    editor.SetAttribute(longOperation.key, longOperation.value);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                {
+                    editor.SetAttribute(floatOperation.key, floatOperation.value);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                {
+                    editor.SetAttribute(doubleOperation.key, doubleOperation.value);
+                }
+
+                if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                {
+                    editor.RemoveAttribute(removeOperation.key);
+                }
+            }
         }
 
         private void TagGroupHelper(List<Channel.TagGroupsEditor.TagOperation> payload, UrbanAirship.Channel.TagGroupsEditor editor)

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -294,45 +294,58 @@ namespace UrbanAirship.NETStandard
             return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
             {
                 var mutations = UAAttributeMutations.Mutations();
-
-                foreach (var operation in operations)
-                {
-                    if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
-                    {
-                        mutations.SetString(stringOperation.value, stringOperation.key);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
-                    {
-                        mutations.SetNumber(intOperation.value, intOperation.key);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
-                    {
-                        mutations.SetNumber(longOperation.value, longOperation.key);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
-                    {
-                        mutations.SetNumber(floatOperation.value, floatOperation.key);
-                    }
-
-                    if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
-                    {
-                        mutations.SetNumber(doubleOperation.value, doubleOperation.key);
-                    }
-
-                    if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
-                    {
-                        mutations.RemoveAttribute(removeOperation.key);
-                    }
-                }
-
+                ApplyAttributesOperations(mutations, operations);
                 UAirship.Channel().ApplyAttributeMutations(mutations);
             });
         }
 
-        private void TagGroupHelper(List<Channel.TagGroupsEditor.TagOperation> operations, bool namedUser)
+        public AttributeEditor EditNamedUserAttributes()
+        {
+            return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
+            {
+                var mutations = UAAttributeMutations.Mutations();
+                ApplyAttributesOperations(mutations, operations);
+                UAirship.NamedUser().ApplyAttributeMutations(mutations);
+            });
+        }
+
+        private void ApplyAttributesOperations(UAAttributeMutations mutations, List<AttributeEditor.IAttributeOperation> operations)
+        {
+            foreach (var operation in operations)
+            {
+                if (operation is AttributeEditor.SetAttributeOperation<string> stringOperation)
+                {
+                    mutations.SetString(stringOperation.value, stringOperation.key);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<int> intOperation)
+                {
+                    mutations.SetNumber(intOperation.value, intOperation.key);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<long> longOperation)
+                {
+                    mutations.SetNumber(longOperation.value, longOperation.key);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<float> floatOperation)
+                {
+                    mutations.SetNumber(floatOperation.value, floatOperation.key);
+                }
+
+                if (operation is AttributeEditor.SetAttributeOperation<double> doubleOperation)
+                {
+                    mutations.SetNumber(doubleOperation.value, doubleOperation.key);
+                }
+
+                if (operation is AttributeEditor.RemoveAttributeOperation removeOperation)
+                {
+                    mutations.RemoveAttribute(removeOperation.key);
+                }
+            }
+        }
+
+            private void TagGroupHelper(List<Channel.TagGroupsEditor.TagOperation> operations, bool namedUser)
         {
             var namedUserActions = new Dictionary<Channel.TagGroupsEditor.OperationType, Action<string, string[]>>()
             {

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -291,6 +291,11 @@ namespace UrbanAirship.NETStandard
 
         public AttributeEditor EditAttributes()
         {
+            return EditChannelAttributes();
+        }
+
+        public AttributeEditor EditChannelAttributes()
+        {
             return new AttributeEditor((List<AttributeEditor.IAttributeOperation> operations) =>
             {
                 var mutations = UAAttributeMutations.Mutations();
@@ -345,7 +350,7 @@ namespace UrbanAirship.NETStandard
             }
         }
 
-            private void TagGroupHelper(List<Channel.TagGroupsEditor.TagOperation> operations, bool namedUser)
+        private void TagGroupHelper(List<Channel.TagGroupsEditor.TagOperation> operations, bool namedUser)
         {
             var namedUserActions = new Dictionary<Channel.TagGroupsEditor.OperationType, Action<string, string[]>>()
             {

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -167,6 +167,7 @@ namespace UrbanAirship.NETStandard
         /// </summary>
         /// <returns>An <see cref="UrbanAirship.NETStandard.Attributes.AttributeEditor">AttributeEditor</see>
         /// for channel attributes.</returns>
+        [Obsolete("This method is deprecated, use EditChannelAttributes() instead.")]
         public Attributes.AttributeEditor EditAttributes()
         {
             throw new NotImplementedException(BaitWithoutSwitchMessage);

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -163,10 +163,31 @@ namespace UrbanAirship.NETStandard
 
         /// <summary>
         /// Edit channel attributes.
+        /// Deprecated : use <see cref="EditChannelAttributes">EditChannelAttributes()</see> instead.
         /// </summary>
         /// <returns>An <see cref="UrbanAirship.NETStandard.Attributes.AttributeEditor">AttributeEditor</see>
         /// for channel attributes.</returns>
         public Attributes.AttributeEditor EditAttributes()
+        {
+            throw new NotImplementedException(BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        /// Edit channel attributes.
+        /// </summary>
+        /// <returns>An <see cref="UrbanAirship.NETStandard.Attributes.AttributeEditor">AttributeEditor</see>
+        /// for channel attributes.</returns>
+        public Attributes.AttributeEditor EditChannelAttributes()
+        {
+            throw new NotImplementedException(BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        /// Edit named user attributes.
+        /// </summary>
+        /// <returns>An <see cref="UrbanAirship.NETStandard.Attributes.AttributeEditor">AttributeEditor</see>
+        /// for named user attributes.</returns>
+        public Attributes.AttributeEditor EditNamedUserAttributes()
         {
             throw new NotImplementedException(BaitWithoutSwitchMessage);
         }


### PR DESCRIPTION
### What do these changes do?
Adds a method to edit named user attributes

### Why are these changes necessary?
To keep the xamarin plugin up to date with the native features

### How did you verify these changes?
In the logs

#### Verification Screenshots:
```
2020-06-10 12:28:28.162 7637-7675/com.urbanairship.sample V/Xamarin Sample - UALib: PreferenceDataStore - Saving preference: com.urbanairship.nameduser.ATTRIBUTE_MUTATION_STORE_KEY value: [[{"timestamp":"2020-06-10T16:27:35","value":"Rico","key":"nickname","action":"set"}],[{"timestamp":"2020-06-10T16:28:28","value":"Rico","key":"nickname","action":"set"}]]
2020-06-10 12:28:28.166 7637-7637/com.urbanairship.sample V/Xamarin Sample - UALib: AirshipService - Received intent: Intent { act=RUN_JOB cmp=com.urbanairship.sample/com.urbanairship.job.AirshipService (has extras) }
2020-06-10 12:28:28.167 7637-7703/com.urbanairship.sample V/Xamarin Sample - UALib: AirshipService - Running job: JobInfo{action=ACTION_UPDATE_NAMED_USER, id=2, extras='{}', airshipComponentName='com.urbanairship.channel.NamedUser', isNetworkAccessRequired=true, initialDelay=0, persistent=false}
2020-06-10 12:28:28.175 7637-7673/com.urbanairship.sample V/Xamarin Sample - UALib: Job - Finished: JobInfo{action=ACTION_UPDATE_NAMED_USER, id=2, extras='{}', airshipComponentName='com.urbanairship.channel.NamedUser', isNetworkAccessRequired=true, initialDelay=0, persistent=false} with result: 0
2020-06-10 12:28:28.178 7637-7703/com.urbanairship.sample V/Xamarin Sample - UALib: AirshipService - Component finished job with startId: 1
2020-06-10 12:28:28.178 7637-7703/com.urbanairship.sample V/Xamarin Sample - UALib: AirshipService - All jobs finished, stopping with last startId: 1
```

```
2020-06-15 09:56:28.920 SampleApp.iOS[353:30161] [D] -[UAAttributeRegistrar updateAttributesForNamedUser:]_block_invoke_4 [Line 203] UAAttributeRegistrar - update named user attribute request failed with status code: 400
```

### Anything else a reviewer should know?
I noticed there is no log when the request is successful on iOS.
So I sent an attribut that doesn't exist in the dashboard to see the method is well called.
