### PR TITLE
[Mobile-1706] - Add message center screen to Xamarin sample

### DIFF
--- a/SampleApp/SampleApp.Android/Resources/drawable/inbox.xml
+++ b/SampleApp/SampleApp.Android/Resources/drawable/inbox.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,3L4.99,3c-1.11,0 -1.98,0.89 -1.98,2L3,19c0,1.1 0.88,2 1.99,2L19,21c1.1,0 2,-0.9 2,-2L21,5c0,-1.11 -0.9,-2 -2,-2zM19,15h-4c0,1.66 -1.35,3 -3,3s-3,-1.34 -3,-3L4.99,15L4.99,5L19,5v10z"/>
+</vector>

--- a/SampleApp/SampleApp.Android/SampleApp.Android.csproj
+++ b/SampleApp/SampleApp.Android/SampleApp.Android.csproj
@@ -140,6 +140,10 @@
       <SubType></SubType>
       <Generator></Generator>
     </AndroidResource>
+    <AndroidResource Include="Resources\drawable\inbox.xml">
+      <SubType></SubType>
+      <Generator></Generator>
+    </AndroidResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\drawable\" />

--- a/SampleApp/SampleApp/AppResources.Designer.cs
+++ b/SampleApp/SampleApp/AppResources.Designer.cs
@@ -59,6 +59,12 @@ namespace SampleApp {
             }
         }
         
+        internal static string message_center_title {
+            get {
+                return ResourceManager.GetString("message_center_title", resourceCulture);
+            }
+        }
+        
         internal static string enable_push {
             get {
                 return ResourceManager.GetString("enable_push", resourceCulture);

--- a/SampleApp/SampleApp/AppResources.resx
+++ b/SampleApp/SampleApp/AppResources.resx
@@ -18,6 +18,9 @@
     <data name="settings_title" xml:space="preserve">
         <value>SETTINGS</value>
     </data>
+    <data name="message_center_title" xml:space="preserve">
+        <value>MESSAGE CENTER</value>
+    </data>
     <data name="enable_push" xml:space="preserve">
         <value>ENABLE PUSH</value>
     </data>

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml
@@ -5,10 +5,30 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="SampleApp.MessageCenterViewController">
     <ContentPage.Content>
-        <ListView x:Name="listView" ItemSelected="listView_ItemSelected">
+        <ListView x:Name="listView" ItemSelected="listView_ItemSelected" RowHeight="70">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <ImageCell Text="{Binding Title}" Detail="{Binding SentDate, StringFormat='{0:MMMM dd, yyyy}'}" ImageSource=""/>
+                    <ViewCell>
+                        <StackLayout Orientation="Horizontal" Padding="20">
+                            <!-- To be used once we add the IsRead attribute-->
+                            <!--<BoxView x:Name="isReadIndicator"
+                                     CornerRadius="7"
+                                     WidthRequest="14" HeightRequest="14">
+                                <BoxView.Triggers>
+                                    <DataTrigger TargetType="BoxView" Binding="{Binding IsRead}" Value="true">
+                                        <Setter Property="BackgroundColor" Value="Green" />
+                                    </DataTrigger>
+                                    <DataTrigger TargetType="BoxView" Binding="{Binding IsRead}" Value="false">
+                                        <Setter Property="BackgroundColor" Value="Blue" />
+                                    </DataTrigger>
+                                </BoxView.Triggers>
+                              </BoxView>-->
+                            <StackLayout>
+                                <Label Text="{Binding Title}"/>
+                                <Label Text="{Binding SentDate, StringFormat='{0:MMMM dd, yyyy, hh:mm}'}" TextColor="Gray"/>
+                            </StackLayout>
+                        </StackLayout>
+                    </ViewCell>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="SampleApp.MessageCenterViewController">
+    <ContentPage.Content>
+    </ContentPage.Content>
+</ContentPage>

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml
@@ -10,19 +10,6 @@
                 <DataTemplate>
                     <ViewCell>
                         <StackLayout Orientation="Horizontal" Padding="20">
-                            <!-- To be used once we add the IsRead attribute-->
-                            <!--<BoxView x:Name="isReadIndicator"
-                                     CornerRadius="7"
-                                     WidthRequest="14" HeightRequest="14">
-                                <BoxView.Triggers>
-                                    <DataTrigger TargetType="BoxView" Binding="{Binding IsRead}" Value="true">
-                                        <Setter Property="BackgroundColor" Value="Green" />
-                                    </DataTrigger>
-                                    <DataTrigger TargetType="BoxView" Binding="{Binding IsRead}" Value="false">
-                                        <Setter Property="BackgroundColor" Value="Blue" />
-                                    </DataTrigger>
-                                </BoxView.Triggers>
-                              </BoxView>-->
                             <StackLayout>
                                 <Label Text="{Binding Title}"/>
                                 <Label Text="{Binding SentDate, StringFormat='{0:MMMM dd, yyyy, hh:mm}'}" TextColor="Gray"/>

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml
@@ -1,7 +1,16 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage
+    Title="{x:Static resources:AppResources.message_center_title}"
+    xmlns:resources="clr-namespace:SampleApp"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="SampleApp.MessageCenterViewController">
     <ContentPage.Content>
+        <ListView x:Name="listView" ItemSelected="listView_ItemSelected">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <ImageCell Text="{Binding Title}" Detail="{Binding SentDate, StringFormat='{0:MMMM dd, yyyy}'}" ImageSource=""/>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </ContentPage.Content>
 </ContentPage>

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml.cs
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace SampleApp
+{
+    public partial class MessageCenterViewController : ContentPage
+    {
+        public MessageCenterViewController()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/SampleApp/SampleApp/MessageCenterViewController.xaml.cs
+++ b/SampleApp/SampleApp/MessageCenterViewController.xaml.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 using Xamarin.Forms;
 
+using UrbanAirship.NETStandard;
+using UrbanAirship.NETStandard.MessageCenter;
+
 namespace SampleApp
 {
     public partial class MessageCenterViewController : ContentPage
@@ -11,5 +14,44 @@ namespace SampleApp
         {
             InitializeComponent();
         }
+
+        protected override void OnAppearing()
+        {
+            var messages = Airship.Instance.InboxMessages;
+            listView.ItemsSource = messages;
+        }
+
+        void listView_ItemSelected(System.Object sender, Xamarin.Forms.SelectedItemChangedEventArgs e)
+        {
+            var message = e.SelectedItem as Message;
+            var messagePage = new MessagePage();
+            messagePage.MessageId = message.MessageId;
+            messagePage.LoadStarted += onLoadStarted;
+            messagePage.Loaded += onLoaded;
+            messagePage.Closed += onClosed;
+            messagePage.LoadFailed += onLoadFailed;
+            Navigation.PushAsync(messagePage);
+        }
+
+        private void onLoadStarted(object sender, MessageLoadStartedEventArgs e)
+        {
+            Console.WriteLine("onLoadStarted was reached.");
+        }
+
+        private void onLoaded(object sender, MessageLoadedEventArgs e)
+        {
+            Console.WriteLine("onLoaded was reached.");
+        }
+
+        private void onClosed(object sender, MessageClosedEventArgs e)
+        {
+            Console.WriteLine("onClosed was reached.");
+        }
+
+        private void onLoadFailed(object sender, MessageLoadFailedEventArgs e)
+        {
+            Console.WriteLine("onLoadFailed was reached.");
+        }
+
     }
 }

--- a/SampleApp/SampleApp/TabbedPageView.xaml
+++ b/SampleApp/SampleApp/TabbedPageView.xaml
@@ -5,4 +5,5 @@
     xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="SampleApp.TabbedPageView">
     <local:HomeViewController Title="{x:Static resources:AppResources.home_title}" IconImageSource="home"/>
     <local:PushSettingsViewController Title="{x:Static resources:AppResources.settings_title}" IconImageSource="settings"/>
+    <local:MessageCenterViewController Title="{x:Static resources:AppResources.message_center_title}" IconImageSource="inbox"/>
 </TabbedPage>

--- a/SampleApp/SampleApp/TabbedPageView.xaml
+++ b/SampleApp/SampleApp/TabbedPageView.xaml
@@ -4,6 +4,6 @@
     xmlns:resources="clr-namespace:SampleApp"
     xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="SampleApp.TabbedPageView">
     <local:HomeViewController Title="{x:Static resources:AppResources.home_title}" IconImageSource="home"/>
-    <local:PushSettingsViewController Title="{x:Static resources:AppResources.settings_title}" IconImageSource="settings"/>
     <local:MessageCenterViewController Title="{x:Static resources:AppResources.message_center_title}" IconImageSource="inbox"/>
+    <local:PushSettingsViewController Title="{x:Static resources:AppResources.settings_title}" IconImageSource="settings"/>
 </TabbedPage>


### PR DESCRIPTION
### What do these changes do?
Add message center screen to Xamarin sample.

### Why are these changes necessary?
To test MessageCenter functionality.

### How did you verify these changes?
Using the sample App.

#### Verification Screenshots:

**iOS**
![iOS1](https://user-images.githubusercontent.com/40355084/86101953-3b042700-babb-11ea-8ddf-a2145175d73d.png)
![iOS2](https://user-images.githubusercontent.com/40355084/86101962-3e97ae00-babb-11ea-928f-7119364de1c6.png)
![iOS3](https://user-images.githubusercontent.com/40355084/86101965-3fc8db00-babb-11ea-891f-57cd75024a76.png)

**Android**
![Android1](https://user-images.githubusercontent.com/40355084/86101976-42c3cb80-babb-11ea-97ca-13f7ac2b8891.png)
![Android2](https://user-images.githubusercontent.com/40355084/86101979-42c3cb80-babb-11ea-8bf0-b50c5b50558e.png)
![Android3](https://user-images.githubusercontent.com/40355084/86101981-435c6200-babb-11ea-8ff4-7e1958eb9c67.png)

### Anything else a reviewer should know?
The **IsRead** attribute is missing now, I added a commented code related to the indicator of isRead message, we can use it once this one is ready.
