### PR TITLE
[MOBILE-1722] standardize event handlers, fix iOS sample crash

### DIFF
--- a/SampleApp/SampleApp.iOS/AppDelegate.cs
+++ b/SampleApp/SampleApp.iOS/AppDelegate.cs
@@ -14,7 +14,6 @@ using CoreFoundation;
 using Sample;
 
 using UrbanAirship;
-using Xamarin.Forms;
 
 namespace SampleApp.iOS
 {
@@ -28,6 +27,10 @@ namespace SampleApp.iOS
 
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
+            global::Xamarin.Forms.Forms.Init();
+            LoadApplication(new App());
+            base.FinishedLaunching(app, options);
+
             this.FailIfSimulator();
 
             // Set log level for debugging config loading (optional)
@@ -73,10 +76,7 @@ namespace SampleApp.iOS
                 //FIXME: Find a way to call the refreshView from the HomeViewController
             });
 
-            global::Xamarin.Forms.Forms.Init();
-            LoadApplication(new App());
-
-            return base.FinishedLaunching(app, options);
+            return true;
         }
 
         private void FailIfSimulator()

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -2,11 +2,21 @@
  Copyright Airship and Contributors
 */
 
+using System;
 using System.Collections.Generic;
 
 
 namespace UrbanAirship.NETStandard
 {
+    public class DeepLinkEventArgs: EventArgs
+    {
+        public string DeepLink { get; internal set; }
+        public DeepLinkEventArgs(string deepLink)
+        {
+            DeepLink = deepLink;
+        }
+    }
+
     public interface IAirship
     {
         bool UserNotificationsEnabled
@@ -38,6 +48,8 @@ namespace UrbanAirship.NETStandard
         {
             get; set;
         }
+
+        event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived;
 
         Channel.TagEditor EditDeviceTags();
 

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -93,8 +93,8 @@ namespace UrbanAirship.NETStandard
             }
         }
 
-        private DeepLinkHandler onDeepLinkReceived;
-        public event DeepLinkHandler OnDeepLinkReceived
+        private EventHandler<DeepLinkEventArgs> onDeepLinkReceived;
+        public event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived
         {
             add
             {
@@ -373,9 +373,11 @@ namespace UrbanAirship.NETStandard
 
         public bool OnDeepLink(string deepLink)
         {
-            var handler = onDeepLinkReceived;
-            handler(deepLink);
-            return true;
+            if (onDeepLinkReceived != null) {
+                onDeepLinkReceived(this, new DeepLinkEventArgs(deepLink));
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -10,8 +10,6 @@ using UrbanAirship.NETStandard.Attributes;
 
 namespace UrbanAirship.NETStandard
 {
-    public delegate void DeepLinkHandler(string deepLink);
-
     public class Airship : UADeepLinkDelegate, IAirship
     {
         private static Airship sharedAirship = new Airship();
@@ -92,8 +90,8 @@ namespace UrbanAirship.NETStandard
             }
         }
 
-        private DeepLinkHandler onDeepLinkReceived;
-        public event DeepLinkHandler OnDeepLinkReceived
+        private EventHandler<DeepLinkEventArgs> onDeepLinkReceived;
+        public event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived
         {
             add
             {
@@ -403,8 +401,7 @@ namespace UrbanAirship.NETStandard
 
         override public void ReceivedDeepLink(NSUrl url, Action completionHandler)
         {
-            var handler = onDeepLinkReceived;
-            handler(url.AbsoluteString);
+            onDeepLinkReceived?.Invoke(this, new DeepLinkEventArgs(url.AbsoluteString));
             completionHandler();
         }
     }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -217,9 +217,7 @@ namespace UrbanAirship.NETStandard
         /// Add/remove the deep link event listener.
         /// </summary>
         /// <value>The deep link event listener.</value>
-        public delegate void DeepLinkHandler(string deepLink);
-
-        public event DeepLinkHandler OnDeepLinkReceived
+        public event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived
         {
             add
             {


### PR DESCRIPTION
We've been slowly moving towards a style of events/delegates that uses `EventHandler<T>` instead of custom delegate types. This brings the deep link events up to date, and also fixes a few issues with the iOS part of the Sample app that I'll call out in the diff.