### PR TITLE
[MOBILE-1670] Update docs and new sample app to make them consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Airship Xamarin Library
 
-This library provides official bindings to the Airship SDK, as well as sample applications for both iOS and Android.
+This library provides official bindings to the Airship SDK, as well as a [cross-platform sample application](SampleApp).
 
-### Resources
+## Resources
 
- - [Xamarin Platform Doc](http://docs.urbanairship.com/platform/xamarin.html)
- - [Getting Started](GettingStarted.md)
- - [CHANGELOG](CHANGELOG.md)
-
+- [Xamarin Platform Doc](http://docs.urbanairship.com/platform/xamarin.html)
+- [Getting Started](GettingStarted.md)
+- [CHANGELOG](CHANGELOG.md)
+- [Cross-platform sample application](SampleApp)
 
 ### Building
 
-Before running the `build.sh` script or trying to build either iOS projects, you must
-run `carthage update` in the root repo directory. This will fetch and build the version
-of iOS Airship SDK defined in the `Cartfile`. Carthage can be installed with
-`brew update && brew install carthage`.
+To build all of the artificats, run `./gradlew build` in the root of the repository.
+The build requires Carthage, which can be installed with `brew update && brew install carthage`.

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ This library provides official bindings to the Airship SDK, as well as a [cross-
 
 ### Building
 
-To build all of the artificats, run `./gradlew build` in the root of the repository.
+To build all of the artifacts, run `./gradlew build` in the root of the repository.
 The build requires Carthage, which can be installed with `brew update && brew install carthage`.

--- a/SampleApp/README.md
+++ b/SampleApp/README.md
@@ -1,0 +1,18 @@
+# Airship Xamarin Cross-Platform Sample App
+
+This cross-platform sample application allows you to experiment with the Airship SDK. It is written using our NETStandard library.
+
+## Resources
+
+- [Xamarin Platform Doc](http://docs.urbanairship.com/platform/xamarin.html)
+- [Getting Started](../GettingStarted.md)
+
+### Building
+
+To build the sample apps, run `./gradlew :SampleApp:build` in the root of the repository.
+The build requires Carthage, which can be installed with `brew update && brew install carthage`.
+Out-of-date packages can get stuck in the nuget cache. If you see this, run `nuget locals global-packages -clear`.
+
+### Running
+
+Once you have built the sample app and its dependencies as above, start VisualStudio and open `SampleApp/SampleApp.sln` to run the iOS or Android flavors of the sample app.

--- a/SampleApp/SampleApp.Android/build.gradle
+++ b/SampleApp/SampleApp.Android/build.gradle
@@ -14,4 +14,5 @@ task build {
     }
 }
 
-build.dependsOn(':SampleApp:build')
+build.dependsOn(':pkg')
+build.dependsOn(':SampleApp:restore')

--- a/SampleApp/SampleApp.iOS/build.gradle
+++ b/SampleApp/SampleApp.iOS/build.gradle
@@ -18,5 +18,5 @@ task build {
     }
 }
 
-build.dependsOn(':SampleApp:build')
-
+build.dependsOn(':pkg')
+build.dependsOn(':SampleApp:restore')

--- a/SampleApp/build.gradle
+++ b/SampleApp/build.gradle
@@ -7,11 +7,16 @@ task clean(type: Delete) {
     }
 }
 
-task build {
+task restore {
+    dependsOn rootProject.pkg
     doLast() {
-     exec {
-         commandLine "mono", "$nugetExe", "restore", "SampleApp.sln"
-     }
+        exec {
+            commandLine "mono", "$nugetExe", "restore", "SampleApp.sln"
+        }
+    }
 }
+
+task build {
+    dependsOn ':SampleApp:SampleApp.iOS:build'
+    dependsOn ':SampleApp:SampleApp.Android:build'
 }
-build.dependsOn(':pkg')

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -15,5 +15,5 @@ within shared codebases (e.g., a Xamarin Forms app).
 Use NuGet to install the urbanairship.netstandard package.
 Detailed instructions can be found in the [Getting started guide](http://docs.urbanairship.com/platform/xamarin.html#installation).
 
-Both Android and iOS example apps are provided in the `samples/` directory on
-[Github](https://github.com/urbanairship/xamarin-component).
+A cross-platform sample app is provided in the `SampleApp` directory on
+[Github](https://github.com/urbanairship/urbanairship-xamarin/tree/main/SampleApp).


### PR DESCRIPTION
### What do these changes do?
Some of the documentation got out-of-date when the new SampleApp was created. This PR fixes the documentation and simplifies and corrects the SampleApp build.

### Why are these changes necessary?
Some complaints on GitHub.

### How did you verify these changes?
Local builds in clean repos.

### Anything else a reviewer should know?
It is now possible to build the Sample App, and it builds both iOS and Android flavors using `./gradlew :SampleApp:build`.