### PR TITLE
[MOBILE-1890] Add a way to mark message center messages read and deleted

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -216,6 +216,16 @@ namespace UrbanAirship.NETStandard
             MessageCenterClass.Shared().ShowMessageCenter(messageId);
         }
 
+        public void MarkMessageRead(string messageId)
+        {
+            MessageCenterClass.Shared().Inbox.GetMessage(messageId).MarkRead();
+        }
+
+        public void DeleteMessage(string messageId)
+        {
+            MessageCenterClass.Shared().Inbox.GetMessage(messageId).Delete();
+        }
+
         public int MessageCenterUnreadCount
         {
             get

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -218,12 +218,20 @@ namespace UrbanAirship.NETStandard
 
         public void MarkMessageRead(string messageId)
         {
-            MessageCenterClass.Shared().Inbox.GetMessage(messageId).MarkRead();
+            var toRead = new List<String>
+            {
+                messageId
+            };
+            MessageCenterClass.Shared().Inbox.MarkMessagesRead(toRead);
         }
 
         public void DeleteMessage(string messageId)
         {
-            MessageCenterClass.Shared().Inbox.GetMessage(messageId).Delete();
+            var toDelete = new List<String>
+            {
+                messageId
+            };
+            MessageCenterClass.Shared().Inbox.DeleteMessages(toDelete);
         }
 
         public int MessageCenterUnreadCount

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -244,6 +244,34 @@ namespace UrbanAirship.NETStandard
             UAMessageCenter.Shared().DisplayMessage(messageId);
         }
 
+        public void MarkMessageRead(string messageId)
+        {
+            var messages = UAMessageCenter.Shared().MessageList.Messages;
+            foreach (var message in messages)
+            {
+                if (message.MessageID == messageId)
+                {
+                    message.MarkMessageRead(null);
+                    Console.WriteLine("Message read !");
+                }
+            }
+        }
+
+        public void DeleteMessage(string messageId)
+        {
+            var toDelete = new UAInboxMessage[1];
+            var messages = UAMessageCenter.Shared().MessageList.Messages;
+            foreach (var message in messages)
+            {
+                if (message.MessageID == messageId)
+                {
+                    toDelete[0] = message;
+                    UAMessageCenter.Shared().MessageList.MarkMessagesDeleted(toDelete, null);
+                    Console.WriteLine("Message deleted !");
+                }
+            }
+        }
+
         public int MessageCenterUnreadCount
         {
             get

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -259,15 +259,8 @@ namespace UrbanAirship.NETStandard
         public void DeleteMessage(string messageId)
         {
             var toDelete = new UAInboxMessage[1];
-            var messages = UAMessageCenter.Shared().MessageList.Messages;
-            foreach (var message in messages)
-            {
-                if (message.MessageID == messageId)
-                {
-                    toDelete[0] = message;
-                    UAMessageCenter.Shared().MessageList.MarkMessagesDeleted(toDelete, null);
-                }
-            }
+            toDelete[0] = UAMessageCenter.Shared().MessageList.Message(messageId);
+            UAMessageCenter.Shared().MessageList.MarkMessagesDeleted(toDelete, null);
         }
 
         public int MessageCenterUnreadCount

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -246,14 +246,9 @@ namespace UrbanAirship.NETStandard
 
         public void MarkMessageRead(string messageId)
         {
-            var messages = UAMessageCenter.Shared().MessageList.Messages;
-            foreach (var message in messages)
-            {
-                if (message.MessageID == messageId)
-                {
-                    message.MarkMessageRead(null);
-                }
-            }
+            var toRead = new UAInboxMessage[1];
+            toRead[0] = UAMessageCenter.Shared().MessageList.Message(messageId);
+            UAMessageCenter.Shared().MessageList.MarkMessagesRead(toRead, null);
         }
 
         public void DeleteMessage(string messageId)

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -252,7 +252,6 @@ namespace UrbanAirship.NETStandard
                 if (message.MessageID == messageId)
                 {
                     message.MarkMessageRead(null);
-                    Console.WriteLine("Message read !");
                 }
             }
         }
@@ -267,7 +266,7 @@ namespace UrbanAirship.NETStandard
                 {
                     toDelete[0] = message;
                     UAMessageCenter.Shared().MessageList.MarkMessagesDeleted(toDelete, null);
-                    Console.WriteLine("Message deleted !");
+                
                 }
             }
         }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -266,7 +266,6 @@ namespace UrbanAirship.NETStandard
                 {
                     toDelete[0] = message;
                     UAMessageCenter.Shared().MessageList.MarkMessagesDeleted(toDelete, null);
-                
                 }
             }
         }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -144,6 +144,24 @@ namespace UrbanAirship.NETStandard
         }
 
         /// <summary>
+        /// Mark a specific message as read
+        /// </summary>
+        /// <param name="messageId">The identifier for the message to mark as read.</param>
+        public void MarkMessageRead(string messageId)
+        {
+            throw new NotImplementedException(BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
+        /// Delete a specific message
+        /// </summary>
+        /// <param name="messageId">The identifier for the message to delete.</param>
+        public void DeleteMessage(string messageId)
+        {
+            throw new NotImplementedException(BaitWithoutSwitchMessage);
+        }
+
+        /// <summary>
         /// Get the message center unread count.
         /// </summary>
         /// <value>The message center unread count.</value>


### PR DESCRIPTION
### What do these changes do?
These changes add methods "MarkAsRead" and "DeleteMessage" to Xamarin NETStandard

### Why are these changes necessary?
Because customers need this

### How did you verify these changes?
By adding a button "mark as read" and "delete" in the sample app, and checking that it's working well.

#### Verification Screenshots:
<!-- ℹ If applicable, please provide screenshots here. -->

### Anything else a reviewer should know?
<!-- ℹ Please provide any additional notes for the reviewer here. -->
