### PR TITLE
[MOBILE-1887] iOS module init

### DIFF
--- a/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -87,7 +87,7 @@
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.1" />
     <PackageReference Include="urbanairship.ios">
-      <Version>13.5.4</Version>
+      <Version>13.5.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -86,11 +86,8 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.1" />
-    <PackageReference Include="urbanairship.ios.core">
-      <Version>13.5.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.messagecenter">
-      <Version>13.5.2</Version>
+    <PackageReference Include="urbanairship.ios">
+      <Version>13.5.4</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -15,12 +15,16 @@ namespace UrbanAirship.NETStandard
         private static Lazy<Airship> sharedAirship = new Lazy<Airship>(() =>
         {
             Airship instance = new Airship();
-            instance.Init();
+            instance.Initialize();
             return instance;
         });
 
-        private void Init()
+        private void Initialize()
         {
+            // Load unreferenced modules
+            AirshipAutomation.Init();
+            AirshipExtendedActions.Init();
+
             NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)"com.urbanairship.channel.channel_created", (NSNotification notification) =>
             {
                 string channelID = notification.UserInfo["com.urbanairship.channel.identifier"].ToString();

--- a/src/AirshipBindings.iOS.Automation/AirshipAutomation.cs
+++ b/src/AirshipBindings.iOS.Automation/AirshipAutomation.cs
@@ -1,0 +1,17 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+namespace UrbanAirship
+{
+    /// <summary>
+    /// Entry point for initializing AirshipAutomation
+    /// </summary>
+    public class AirshipAutomation
+    {
+        /// <summary>
+        /// Initializes AirshipAutomation.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
+++ b/src/AirshipBindings.iOS.Automation/AirshipBindings.iOS.Automation.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\SharedAssemblyInfo.iOS.cs">
       <Link>Properties\SharedAssemblyInfo.iOS.cs</Link>
     </Compile>
+    <Compile Include="AirshipAutomation.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
+++ b/src/AirshipBindings.iOS.Core/AirshipBindings.iOS.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\SharedAssemblyInfo.Common.cs">
       <Link>Properties\SharedAssemblyInfo.Common.cs</Link>
     </Compile>
+    <Compile Include="AirshipCore.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/AirshipBindings.iOS.Core/AirshipCore.cs
+++ b/src/AirshipBindings.iOS.Core/AirshipCore.cs
@@ -1,0 +1,17 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+namespace UrbanAirship
+{
+    /// <summary>
+    /// Entry point for initializing AirshipCore
+    /// </summary>
+    public class AirshipCore
+    {
+        /// <summary>
+        /// Initializes AirshipCore.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.iOS.ExtendedActions/AirshipBindings.iOS.ExtendedActions.csproj
+++ b/src/AirshipBindings.iOS.ExtendedActions/AirshipBindings.iOS.ExtendedActions.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\SharedAssemblyInfo.iOS.cs">
       <Link>Properties\SharedAssemblyInfo.iOS.cs</Link>
     </Compile>
+    <Compile Include="AirshipExtendedActions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/AirshipBindings.iOS.ExtendedActions/AirshipExtendedActions.cs
+++ b/src/AirshipBindings.iOS.ExtendedActions/AirshipExtendedActions.cs
@@ -1,0 +1,17 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+namespace UrbanAirship
+{
+    /// <summary>
+    /// Entry point for initializing AirshipExtendedActions
+    /// </summary>
+    public class AirshipExtendedActions
+    {
+        /// <summary>
+        /// Initializes AirshipExtendedActions.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.iOS.Location/AirshipBindings.iOS.Location.csproj
+++ b/src/AirshipBindings.iOS.Location/AirshipBindings.iOS.Location.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\SharedAssemblyInfo.iOS.cs">
       <Link>Properties\SharedAssemblyInfo.iOS.cs</Link>
     </Compile>
+    <Compile Include="AirshipLocation.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/AirshipBindings.iOS.Location/AirshipLocation.cs
+++ b/src/AirshipBindings.iOS.Location/AirshipLocation.cs
@@ -1,0 +1,17 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+namespace UrbanAirship
+{
+    /// <summary>
+    /// Entry point for initializing AirshipLocation
+    /// </summary>
+    public class AirshipLocation
+    {
+        /// <summary>
+        /// Initializes AirshipLocation.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
+++ b/src/AirshipBindings.iOS.MessageCenter/AirshipBindings.iOS.MessageCenter.csproj
@@ -41,6 +41,7 @@
     <Compile Include="..\SharedAssemblyInfo.iOS.cs">
       <Link>Properties\SharedAssemblyInfo.iOS.cs</Link>
     </Compile>
+    <Compile Include="AirshipMessageCenter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />

--- a/src/AirshipBindings.iOS.MessageCenter/AirshipMessageCenter.cs
+++ b/src/AirshipBindings.iOS.MessageCenter/AirshipMessageCenter.cs
@@ -1,0 +1,17 @@
+﻿/*
+ Copyright Airship and Contributors
+*/
+
+namespace UrbanAirship
+{
+    /// <summary>
+    /// Entry point for initializing AirshipMessageCenter
+    /// </summary>
+    public class AirshipMessageCenter
+    {
+        /// <summary>
+        /// Initializes AirshipMessageCenter.
+        /// </summary>
+        public static void Init() { }
+    }
+}

--- a/src/AirshipBindings.iOS.common/build.gradle
+++ b/src/AirshipBindings.iOS.common/build.gradle
@@ -22,7 +22,7 @@ task carthageUpdate {
     doLast() {
         exec {
             workingDir "$rootDir"
-            commandLine "carthage", "update"
+            commandLine "./wcarthage",  "update"
         }
     }
 }
@@ -39,7 +39,7 @@ task carthageCheckout {
     doLast() {
         exec {
             workingDir "$rootDir"
-            commandLine "carthage", "checkout"
+            commandLine "./wcarthage", "checkout"
         }
     }
 }

--- a/wcarthage
+++ b/wcarthage
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+echo "Carthage wrapper"
+echo "Applying Xcode 12 workaround..."
+xcconfig="/tmp/xc12-carthage.xcconfig"
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' > $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+echo 'ONLY_ACTIVE_ARCH=NO' >> $xcconfig
+echo 'VALID_ARCHS = $(inherited) x86_64' >> $xcconfig
+export XCODE_XCCONFIG_FILE="$xcconfig"
+echo "Workaround applied. xcconfig here: $XCODE_XCCONFIG_FILE"
+
+carthage $@


### PR DESCRIPTION
We've had a few reports that IAA doesn't work in Xamarin, and it turns out that the module is being stripped out when it's not referenced in code. I've tried various things from linker settings to Preserve annotations, but the one thing that seems to work is adding a dummy  static "Init" method that can be called to force the compiler to include the module. This is a potential problem for any module aside from AirshpCore, which you already have to reference in order to call takeOff.

Since the NETStandard library only directly references Core and Message Center, I modified it to initialize Automation and Extended Actions, so that NETStandard users don't have to bother about this. Native apps will need to call the appropriate init methods for the modules they're using, which will need clear documentation.

Tested this by building the packages locally, running our SampleApp and verifying that an automation I sent to myself was displayed.