### PR TITLE
[carthage-wrapper] wcarthage

### DIFF
--- a/src/AirshipBindings.iOS.common/build.gradle
+++ b/src/AirshipBindings.iOS.common/build.gradle
@@ -22,7 +22,7 @@ task carthageUpdate {
     doLast() {
         exec {
             workingDir "$rootDir"
-            commandLine "carthage", "update"
+            commandLine "./wcarthage",  "update"
         }
     }
 }
@@ -39,7 +39,7 @@ task carthageCheckout {
     doLast() {
         exec {
             workingDir "$rootDir"
-            commandLine "carthage", "checkout"
+            commandLine "./wcarthage", "checkout"
         }
     }
 }

--- a/wcarthage
+++ b/wcarthage
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+echo "Carthage wrapper"
+echo "Applying Xcode 12 workaround..."
+xcconfig="/tmp/xc12-carthage.xcconfig"
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_12A7209 = arm64 arm64e armv7 armv7s armv6 armv8' > $xcconfig
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+echo 'ONLY_ACTIVE_ARCH=NO' >> $xcconfig
+echo 'VALID_ARCHS = $(inherited) x86_64' >> $xcconfig
+export XCODE_XCCONFIG_FILE="$xcconfig"
+echo "Workaround applied. xcconfig here: $XCODE_XCCONFIG_FILE"
+
+carthage $@


### PR DESCRIPTION
This is a temporary workaround for https://github.com/Carthage/Carthage/issues/3019. Carthage is incompatable with XCode 12 at the moment due to the presence of arm64 simulator slices. This script wraps the carthage command to exclude that architecture.