### PR TITLE
fix OnChannelUpdate event

### DIFF
--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -30,7 +30,7 @@ namespace UrbanAirship.NETStandard
             NSNotificationCenter.DefaultCenter.AddObserver(aName: (NSString)"com.urbanairship.channel.channel_updated", (NSNotification notification) =>
             {
                 string channelID = notification.UserInfo["com.urbanairship.channel.identifier"].ToString();
-                OnChannelCreation?.Invoke(this, new ChannelEventArgs(channelID));
+                OnChannelUpdate?.Invoke(this, new ChannelEventArgs(channelID));
             });
 
             //Adding Inbox updated Listener


### PR DESCRIPTION
I noticed this when working on something else. VS was warning about OnChannelUpdate being unused, and it turned out that we were calling the OnChannelCreation event for both creation and updates. This fixes it.