### PR TITLE
[MOBILE-1748] install xamboni through pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,6 @@ google-services.json
 
 # Airship
 airship.properties
+
+# Xamboni
+src/xamboni/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "xamboni"]
-	path = xamboni
-	url = git@github.com:urbanairship/xamboni.git

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ This library provides official bindings to the Airship SDK, as well as a [cross-
 
 To build all of the artifacts, run `./gradlew build` in the root of the repository.
 The build requires Carthage, which can be installed with `brew update && brew install carthage`.
+
+To install required Python scripts and dependencies, run `pip install -r requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==5.3.1
+-e git+ssh://git@github.com/urbanairship/xamboni.git#egg=Xamboni

--- a/src/ios-common-build.gradle
+++ b/src/ios-common-build.gradle
@@ -89,7 +89,7 @@ task generateIOSBindings {
         println("Generating bindings for ${iosSdkModuleName} module.")
 
         def xamboniScript = "xamboni.py"
-        def xamboniDir = new File ("${rootDir}/xamboni")
+        def xamboniDir = new File ("${rootDir}/src/xamboni")
         def xamboniFile = new File (xamboniDir, xamboniScript)
         if (!xamboniFile.exists()) {
             throw new GradleException("ERROR: Cannot find ${xamboniFile}. Please run 'git submodule update --init --recursive'")


### PR DESCRIPTION
This installs xamboni through pip instead of a git submodule. Since xamboni is private for now we can just point pip to the github repo, with `@foo` suffixes after `.git` to specify branches or specific commits if necessary. `requirements.txt` is the typical way to lock dependencies in this ecosystem. Aside from the new installation mechanism the only real change here is that the location of the xamboni directory has moved to `src`.