### PR TITLE
[MOBILE-1932] Add Xamarin forms message center listener

### DIFF
--- a/SampleApp/SampleApp/App.xaml.cs
+++ b/SampleApp/SampleApp/App.xaml.cs
@@ -44,7 +44,7 @@ namespace SampleApp
         {
             Console.WriteLine("onMessageCenterUpdated");
         }
-        static void OnMessageCenterDisplay(object sender, EventArgs e)
+        static void OnMessageCenterDisplay(object sender, MessageCenterEventArgs e)
         {
             TabbedPage originalRootPage = (TabbedPage)App.Current.MainPage.Navigation.NavigationStack.Last();
 

--- a/SampleApp/SampleApp/App.xaml.cs
+++ b/SampleApp/SampleApp/App.xaml.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 using UrbanAirship.NETStandard;
+using System.Linq;
 
 namespace SampleApp
 {
@@ -23,6 +24,7 @@ namespace SampleApp
         {
             Airship.Instance.OnDeepLinkReceived += OnDeepLinkReceived;
             Airship.Instance.OnMessageCenterUpdated += OnMessageCenterUpdated;
+            Airship.Instance.OnMessageCenterDisplay += OnMessageCenterDisplay;
         }
 
         protected override void OnSleep()
@@ -41,6 +43,12 @@ namespace SampleApp
         static void OnMessageCenterUpdated(object sender, EventArgs e)
         {
             Console.WriteLine("onMessageCenterUpdated");
+        }
+        static void OnMessageCenterDisplay(object sender, EventArgs e)
+        {
+            TabbedPage originalRootPage = (TabbedPage)App.Current.MainPage.Navigation.NavigationStack.Last();
+
+            originalRootPage.CurrentPage = originalRootPage.Children[1];
         }
     }
 }

--- a/SampleApp/SampleApp/App.xaml.cs
+++ b/SampleApp/SampleApp/App.xaml.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 using UrbanAirship.NETStandard;
+using UrbanAirship.NETStandard.MessageCenter;
 using System.Linq;
 
 namespace SampleApp
@@ -49,6 +50,13 @@ namespace SampleApp
             TabbedPage originalRootPage = (TabbedPage)App.Current.MainPage.Navigation.NavigationStack.Last();
 
             originalRootPage.CurrentPage = originalRootPage.Children[1];
+
+            if (e.MessageId != null)
+            {
+                var messagePage = new MessagePage();
+                messagePage.MessageId = e.MessageId;
+                originalRootPage.Navigation.PushAsync(messagePage);
+            }
         }
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Abstractions/IAirship.cs
@@ -28,6 +28,15 @@ namespace UrbanAirship.NETStandard
         }
     }
 
+    public class MessageCenterEventArgs : EventArgs
+    {
+        public string MessageId { get; internal set; }
+        public MessageCenterEventArgs(string messageId = null)
+        {
+            MessageId = messageId;
+        }
+    }
+
     public interface IAirship
     {
         bool UserNotificationsEnabled
@@ -66,6 +75,8 @@ namespace UrbanAirship.NETStandard
 
         event EventHandler<DeepLinkEventArgs> OnDeepLinkReceived;
 
+        event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay;
+
         Channel.TagEditor EditDeviceTags();
 
         void AddCustomEvent(Analytics.CustomEvent customEvent);
@@ -98,7 +109,7 @@ namespace UrbanAirship.NETStandard
         Attributes.AttributeEditor EditAttributes();
 
         event EventHandler OnMessageCenterUpdated;
-      
+
         Attributes.AttributeEditor EditChannelAttributes();
 
         Attributes.AttributeEditor EditNamedUserAttributes();

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -57,6 +57,8 @@ namespace UrbanAirship.NETStandard
 
         public event EventHandler OnMessageCenterUpdated;
 
+        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay;
+
         public static Airship Instance
         {
             get
@@ -211,12 +213,26 @@ namespace UrbanAirship.NETStandard
 
         public void DisplayMessageCenter()
         {
-            MessageCenterClass.Shared().ShowMessageCenter();
+            if (OnMessageCenterDisplay != null)
+            {
+                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs());
+            }
+            else
+            {
+                MessageCenterClass.Shared().ShowMessageCenter();
+            }
         }
 
         public void DisplayMessage(string messageId)
         {
-            MessageCenterClass.Shared().ShowMessageCenter(messageId);
+            if (OnMessageCenterDisplay != null)
+            {
+                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs(messageId));
+            }
+            else
+            {
+                MessageCenterClass.Shared().ShowMessageCenter(messageId);
+            }
         }
 
         public void MarkMessageRead(string messageId)

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.Android/Airship.cs
@@ -14,7 +14,7 @@ using UrbanAirship.Automation;
 
 namespace UrbanAirship.NETStandard
 { 
-    public class Airship : Java.Lang.Object, IDeepLinkListener, IAirship, IInboxListener, UrbanAirship.Channel.IAirshipChannelListener
+    public class Airship : Java.Lang.Object, IDeepLinkListener, IAirship, IInboxListener, MessageCenterClass.IOnShowMessageCenterListener, UrbanAirship.Channel.IAirshipChannelListener
     {
         private static Lazy<Airship> sharedAirship = new Lazy<Airship>(() =>
         {
@@ -57,7 +57,25 @@ namespace UrbanAirship.NETStandard
 
         public event EventHandler OnMessageCenterUpdated;
 
-        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay;
+        private EventHandler<MessageCenterEventArgs> onMessageCenterDisplay;
+        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
+        {
+            add
+            {
+                onMessageCenterDisplay += value;
+                MessageCenterClass.Shared().SetOnShowMessageCenterListener(this);
+            }
+
+            remove
+            {
+                onMessageCenterDisplay -= value;
+
+                if (onMessageCenterDisplay == null)
+                {
+                    MessageCenterClass.Shared().SetOnShowMessageCenterListener(null);
+                }
+            }
+        }
 
         public static Airship Instance
         {
@@ -213,26 +231,12 @@ namespace UrbanAirship.NETStandard
 
         public void DisplayMessageCenter()
         {
-            if (OnMessageCenterDisplay != null)
-            {
-                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs());
-            }
-            else
-            {
-                MessageCenterClass.Shared().ShowMessageCenter();
-            }
+            MessageCenterClass.Shared().ShowMessageCenter();
         }
 
         public void DisplayMessage(string messageId)
         {
-            if (OnMessageCenterDisplay != null)
-            {
-                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs(messageId));
-            }
-            else
-            {
-                MessageCenterClass.Shared().ShowMessageCenter(messageId);
-            }
+            MessageCenterClass.Shared().ShowMessageCenter(messageId);
         }
 
         public void MarkMessageRead(string messageId)
@@ -475,6 +479,17 @@ namespace UrbanAirship.NETStandard
         {
             if (onDeepLinkReceived != null) {
                 onDeepLinkReceived(this, new DeepLinkEventArgs(deepLink));
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool OnShowMessageCenter(string messageId)
+        {
+            if (onMessageCenterDisplay != null)
+            {
+                onMessageCenterDisplay(this, new MessageCenterEventArgs(messageId));
                 return true;
             }
 

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -74,6 +74,8 @@ namespace UrbanAirship.NETStandard
         }
         public event EventHandler OnMessageCenterUpdated;
 
+        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay;
+
         public static Airship Instance
         {
             get
@@ -247,12 +249,27 @@ namespace UrbanAirship.NETStandard
 
         public void DisplayMessageCenter()
         {
-            UAMessageCenter.Shared().Display();
+            if (OnMessageCenterDisplay != null)
+            {
+                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs());
+            }
+            else
+            {
+                UAMessageCenter.Shared().Display();
+            }
+  
         }
 
         public void DisplayMessage(string messageId)
         {
-            UAMessageCenter.Shared().DisplayMessage(messageId);
+            if (OnMessageCenterDisplay != null)
+            {
+                OnMessageCenterDisplay.Invoke(this, new MessageCenterEventArgs(messageId));
+            }
+            else
+            {
+                UAMessageCenter.Shared().DisplayMessage(messageId);
+            }
         }
 
         public void MarkMessageRead(string messageId)

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -541,7 +541,5 @@ namespace UrbanAirship.NETStandard
                 UAInAppAutomation.Shared().InAppMessageManager.DisplayInterval = value.TotalSeconds;
             }
         }
-
-        public IntPtr Handle => throw new NotImplementedException();
     }
 }

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard/Airship.cs
@@ -277,6 +277,23 @@ namespace UrbanAirship.NETStandard
         }
 
         /// <summary>
+        /// Add/remove the message center display event listener.
+        /// </summary>
+        /// <value>The message center display listener.</value>
+        public event EventHandler<MessageCenterEventArgs> OnMessageCenterDisplay
+        {
+            add
+            {
+                throw new NotImplementedException(BaitWithoutSwitchMessage);
+            }
+
+            remove
+            {
+                throw new NotImplementedException(BaitWithoutSwitchMessage);
+            }
+        }
+
+        /// <summary>
         /// Add/remove the channel creation event listener.
         /// </summary>
         /// <value>The channel creation event listener.</value>

--- a/wcarthage
+++ b/wcarthage
@@ -3,7 +3,7 @@ echo "Carthage wrapper"
 echo "Applying Xcode 12 workaround..."
 xcconfig="/tmp/xc12-carthage.xcconfig"
 root_path=`dirname "${0}"`
-buildnum=`$root_path/get_xcode_version.sh 12.0`
+buildnum=`$root_path/get_xcode_version.sh 12.0.1`
 echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$buildnum = arm64 arm64e armv7 armv7s armv6 armv8" > $xcconfig
 echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig


### PR DESCRIPTION
### What do these changes do?
Add a message center display listener. If set, displayMessageCenter and displayMessage route to the built in message center. If not, the default message center is displayed.

### Why are these changes necessary?
Allow for the custom Xamarin Forms MC to be used instead of the OOTB one.

### How did you verify these changes?
Ran sample apps and verified that the behavior is as expected.
