### PR TITLE
Release SDK 15.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Airship Xamarin Changelog
 
+## Version 15.0.3 - January 20, 2022
+Minor release fixing an issue with nuget package path length.
+
+### Changes
+- Reduce nuget package path length.
 
 ## Version 15.0.2 - January 12, 2022
-Minor release updating to latest Android Airship SDK and fixing an issue with nuget package path length.
+Minor release updating to latest Android Airship SDK.
 
 ### Changes
 - Updated Android SDK to 16.1.1
-- Reduce nuget package path length.
 
 ## Version 15.0.1 - Dec 22, 2021
 Minor release updating to latest iOS Airship SDK.

--- a/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -88,32 +88,32 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="urbanairship.ios.accengage">
-      <Version>16.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.basement">
-      <Version>16.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.extendedactions">
-      <Version>16.1.2</Version>
-    </PackageReference>
     <PackageReference Include="urbanairship.ios.messagecenter">
-      <Version>16.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.location">
-      <Version>16.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.chat">
-      <Version>16.1.2</Version>
-    </PackageReference>
-    <PackageReference Include="urbanairship.ios.core">
-      <Version>16.1.2</Version>
+      <Version>16.1.2.1</Version>
     </PackageReference>
     <PackageReference Include="urbanairship.ios.automation">
-      <Version>16.1.2</Version>
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.basement">
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.accengage">
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.extendedactions">
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.core">
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.location">
+      <Version>16.1.2.1</Version>
     </PackageReference>
     <PackageReference Include="urbanairship.ios.preferencecenter">
-      <Version>16.1.2</Version>
+      <Version>16.1.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="urbanairship.ios.chat">
+      <Version>16.1.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/SampleApp/SampleApp.iOS/SampleContentExtension/SampleContentExtension.csproj
+++ b/SampleApp/SampleApp.iOS/SampleContentExtension/SampleContentExtension.csproj
@@ -86,7 +86,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="AirshipBindings.iOS.NotificationContentExtension">
-      <HintPath>..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2\lib\Xamarin.iOS10\AirshipBindings.iOS.NotificationContentExtension.dll</HintPath>
+      <HintPath>..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2.1\lib\Xamarin.iOS10\AirshipBindings.iOS.NotificationContentExtension.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -136,4 +136,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
   <Import Project="..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2\build\urbanairship.ios.notificationcontentextension.targets" Condition="Exists('..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2\build\urbanairship.ios.notificationcontentextension.targets')" />
+  <Import Project="..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2.1\build\urbanairship.ios.notificationcontentextension.targets" Condition="Exists('..\..\packages\urbanairship.ios.notificationcontentextension.16.1.2.1\build\urbanairship.ios.notificationcontentextension.targets')" />
 </Project>

--- a/SampleApp/SampleApp.iOS/SampleContentExtension/packages.config
+++ b/SampleApp/SampleApp.iOS/SampleContentExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="urbanairship.ios.notificationcontentextension" version="16.1.2" targetFramework="xamarinios10" />
+  <package id="urbanairship.ios.notificationcontentextension" version="16.1.2.1" targetFramework="xamarinios10" />
 </packages>

--- a/SampleApp/SampleApp.iOS/SampleServiceExtension/SampleServiceExtension.csproj
+++ b/SampleApp/SampleApp.iOS/SampleServiceExtension/SampleServiceExtension.csproj
@@ -86,7 +86,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="AirshipBindings.iOS.NotificationServiceExtension">
-      <HintPath>..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2\lib\Xamarin.iOS10\AirshipBindings.iOS.NotificationServiceExtension.dll</HintPath>
+      <HintPath>..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2.1\lib\Xamarin.iOS10\AirshipBindings.iOS.NotificationServiceExtension.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -135,4 +135,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
   <Import Project="..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2\build\urbanairship.ios.notificationserviceextension.targets" Condition="Exists('..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2\build\urbanairship.ios.notificationserviceextension.targets')" />
+  <Import Project="..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2.1\build\urbanairship.ios.notificationserviceextension.targets" Condition="Exists('..\..\packages\urbanairship.ios.notificationserviceextension.16.1.2.1\build\urbanairship.ios.notificationserviceextension.targets')" />
 </Project>

--- a/SampleApp/SampleApp.iOS/SampleServiceExtension/packages.config
+++ b/SampleApp/SampleApp.iOS/SampleServiceExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="urbanairship.ios.notificationserviceextension" version="16.1.2" targetFramework="xamarinios10" />
+  <package id="urbanairship.ios.notificationserviceextension" version="16.1.2.1" targetFramework="xamarinios10" />
 </packages>

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2244" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Xamarin.Plugins.Clipboard" Version="2.3.0" />
-    <PackageReference Include="urbanairship.netstandard" Version="15.0.2" />
+    <PackageReference Include="urbanairship.netstandard" Version="15.0.3" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="AppResources.resx">

--- a/UrbanAirship.NETStandard.nuspec
+++ b/UrbanAirship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.netstandard</id>
-      <version>15.0.2</version>
+      <version>15.0.3</version>
       <title>Airship SDK .NET Standard Library</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -20,10 +20,10 @@
          </group>
 
          <group targetFramework="Xamarin.iOS1.0">
-            <dependency id="urbanairship.ios.core" version="16.1.2"/>
-            <dependency id="urbanairship.ios.automation" version="16.1.2"/>
-            <dependency id="urbanairship.ios.extendedactions" version="16.1.2"/>
-            <dependency id="urbanairship.ios.messagecenter" version="16.1.2"/>
+            <dependency id="urbanairship.ios.core" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.automation" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.extendedactions" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.messagecenter" version="16.1.2.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.iOS.Accengage.nuspec
+++ b/UrbanAirship.iOS.Accengage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.accengage</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Accengage</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.Automation.nuspec
+++ b/UrbanAirship.iOS.Automation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.automation</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Automation</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.Basement.nuspec
+++ b/UrbanAirship.iOS.Basement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.basement</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Basement</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.Chat.nuspec
+++ b/UrbanAirship.iOS.Chat.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.chat</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Chat</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.Core.nuspec
+++ b/UrbanAirship.iOS.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.core</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Core</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.ExtendedActions.nuspec
+++ b/UrbanAirship.iOS.ExtendedActions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.extendedactions</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - ExtendedActions</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.Location.nuspec
+++ b/UrbanAirship.iOS.Location.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.location</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Location</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.MessageCenter.nuspec
+++ b/UrbanAirship.iOS.MessageCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.messagecenter</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - MessageCenter</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.NotificationContentExtension.nuspec
+++ b/UrbanAirship.iOS.NotificationContentExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.notificationcontentextension</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Notification Content Extension</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.NotificationServiceExtension.nuspec
+++ b/UrbanAirship.iOS.NotificationServiceExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.notificationserviceextension</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Notification Service Extension</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.PreferenceCenter.nuspec
+++ b/UrbanAirship.iOS.PreferenceCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios.preferencecenter</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK - Preference Center</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/UrbanAirship.iOS.nuspec
+++ b/UrbanAirship.iOS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.ios</id>
-      <version>16.1.2</version>
+      <version>16.1.2.1</version>
       <title>Airship iOS SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,12 +11,12 @@
 
       <dependencies>
          <group>
-            <dependency id="urbanairship.ios.basement" version="16.1.2"/>           
-            <dependency id="urbanairship.ios.core" version="16.1.2"/>
-            <dependency id="urbanairship.ios.automation" version="16.1.2"/>
-            <dependency id="urbanairship.ios.extendedactions" version="16.1.2"/>
-            <dependency id="urbanairship.ios.messagecenter" version="16.1.2"/>
-            <dependency id="urbanairship.ios.preferencecenter" version="16.1.2"/>
+            <dependency id="urbanairship.ios.basement" version="16.1.2.1"/>           
+            <dependency id="urbanairship.ios.core" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.automation" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.extendedactions" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.messagecenter" version="16.1.2.1"/>
+            <dependency id="urbanairship.ios.preferencecenter" version="16.1.2.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,4 @@
-crossPlatformVersion = 15.0.2
+crossPlatformVersion = 15.0.3
+iosNugetVersion = 16.1.2.1
 iosVersion = 16.1.2
 androidVersion = 16.1.1

--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,9 @@ task syncRootVersion {
             androidNugetVersion = "${airshipProperties.androidVersion}.${airshipProperties.androidPackageVersion}"
         }
 
-        def iosNugetVersion = airshipProperties.iosVersion
+        def iosNugetVersion = airshipProperties.iosNugetVersion
         if (airshipProperties['iosPackageVersion']) {
-            iosNugetVersion = "${airshipProperties.iosVersion}.${airshipProperties.iosPackageVersion}"
+            iosNugetVersion = "${airshipProperties.iosNugetVersion}.${airshipProperties.iosPackageVersion}"
         }
 
         // Handle Android nuspec versions
@@ -162,7 +162,7 @@ task syncRootVersion {
         ant.replaceregexp(
             file: "$projectDir/src/SharedAssemblyInfo.iOS.cs",
             match: "AssemblyVersion (.*)]",
-            replace: "AssemblyVersion (\"$airshipProperties.iosVersion\")]"
+            replace: "AssemblyVersion (\"$airshipProperties.iosNugetVersion\")]"
         )
 
         ant.replaceregexp(

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("15.0.2")]
+[assembly: UACrossPlatformVersion ("15.0.3")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("15.0.2")]
+[assembly: AssemblyVersion ("15.0.3")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,5 +17,5 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("16.1.2")]
+[assembly: AssemblyVersion ("16.1.2.1")]
 


### PR DESCRIPTION
Release SDK 15.0.3

### What do these changes do?
Contain the reduce nuget package path issue

### Anything else a reviewer should know?
I added a new value to the airship.properties file called **iosNugetVersion** to differentiate the nuget version from the iOS sdk version. I will create a ticket for Android since it's not a priority now and we need to release this version as soon as possible.
