### PR TITLE
Release 17.0.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get Version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Verify Version
         run: |
@@ -29,21 +29,12 @@ jobs:
         run: |
           VERSION=${{ steps.get_version.outputs.VERSION }}
           NOTES="$(awk "/## Version $VERSION/{flag=1;next}/## Version/{flag=0}flag" CHANGELOG.md)"
-          NOTES="${NOTES//'%'/'%25'}"
-          NOTES="${NOTES//$'\n'/'%0A'}"
-          NOTES="${NOTES//$'\r'/'%0D'}"
-          echo ::set-output name=NOTES::"$NOTES"
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
+          echo "NOTES=${NOTES}" >> $GITHUB_OUTPUT
           
-      - name: Setup GCP
-        uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
+      - name: Setup GCP Auth
+        uses: google-github-actions/auth@v1
         with:
-          version: '351.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
@@ -69,10 +60,11 @@ jobs:
           NUGET_PRODUCTION_API_KEY: ${{ secrets.NUGET_PRODUCTION_API_KEY }}
         run: ./gradlew publishToProduction
 
-      - name: Upload Docs
-        run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/xamarin/$VERSION.tar.gz
+      - name: Upload docs
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: docs/build/${{ steps.get_version.outputs.VERSION }}.tar.gz
+          destination: ua-web-ci-prod-docs-transfer/libraries/xamarin/${{ steps.get_version.outputs.VERSION }}.tar.gz
 
       - name: Create Github Release
         uses: actions/create-release@v1.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -220,7 +220,7 @@ docs/doxygen.tag
 local-nuget-feed/
 
 # UA native jars
-src/AirshipBindings.Android.*/Jars/urbanairship*.arr
+src/**/Jars/
 
 # Google Services (e.g. APIs or Firebase)
 #SampleApp/SampleApp.Android/Assets/google-services.json

--- a/Airship.Android.ADM.nuspec
+++ b/Airship.Android.ADM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.adm</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK - ADM Push Provider</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.Accengage.nuspec
+++ b/Airship.Android.Accengage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.accengage</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK - Accengage</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>  
+            <dependency id="airship.android.core" version="16.9.1"/>  
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.Automation.nuspec
+++ b/Airship.Android.Automation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.automation</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,8 +11,8 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
-            <dependency id="airship.android.layout" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
+            <dependency id="airship.android.layout" version="16.9.1"/>
             <dependency id="Xamarin.AndroidX.CustomView" version="1.1.0.4" />
             <dependency id="Xamarin.AndroidX.Room.Runtime" version="2.4.3"/>
          </group>

--- a/Airship.Android.Chat.nuspec
+++ b/Airship.Android.Chat.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.chat</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
             <dependency id="Xamarin.Kotlin.StdLib" version="1.5.31.2" />
             <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.5.31.2" />
             <dependency id="Xamarin.KotlinX.Coroutines.Core" version="1.5.2.2" />

--- a/Airship.Android.Core.nuspec
+++ b/Airship.Android.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.core</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.Android.FCM.nuspec
+++ b/Airship.Android.FCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.fcm</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK - FCM Push Provider</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -14,7 +14,7 @@
             <dependency id="Xamarin.Firebase.Messaging" version="122.0.0.1" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="117.6.0.1" />
             <dependency id="Xamarin.Google.Dagger" version="2.37.0" />
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.Layout.nuspec
+++ b/Airship.Android.Layout.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.layout</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
             <dependency id="Xamarin.AndroidX.ConstraintLayout" version="2.1.1.2" />
             <dependency id="Xamarin.AndroidX.AppCompat" version="1.3"/>
          </group>

--- a/Airship.Android.Location.nuspec
+++ b/Airship.Android.Location.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.location</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.MessageCenter.nuspec
+++ b/Airship.Android.MessageCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.messagecenter</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.1.0.1" />
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
             <dependency id="Xamarin.AndroidX.Room.Runtime" version="2.4.3"/>
          </group>
       </dependencies>

--- a/Airship.Android.Preference.nuspec
+++ b/Airship.Android.Preference.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.preference</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK - Preference Module</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.AndroidX.Preference" version="1.1.1.6"/>
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.PreferenceCenter.nuspec
+++ b/Airship.Android.PreferenceCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.preferencecenter</id>
-      <version>16.9.0</version>
+      <version>16.9.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
             <dependency id="Xamarin.Kotlin.StdLib" version="1.5.31.2" />
             <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.5.31.2" />
             <dependency id="Xamarin.KotlinX.Coroutines.Core" version="1.5.2.2" />

--- a/Airship.NETStandard.nuspec
+++ b/Airship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.netstandard</id>
-      <version>17.0.1</version>
+      <version>17.0.2</version>
       <title>Airship SDK .NET Standard Library</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -13,17 +13,17 @@
          <group targetFramework=".NETStandard2.0">
          </group>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="16.9.0"/>
-            <dependency id="airship.android.messagecenter" version="16.9.0"/>
-            <dependency id="airship.android.automation" version="16.9.0"/>
-            <dependency id="airship.android.location" version="16.9.0"/>
+            <dependency id="airship.android.core" version="16.9.1"/>
+            <dependency id="airship.android.messagecenter" version="16.9.1"/>
+            <dependency id="airship.android.automation" version="16.9.1"/>
+            <dependency id="airship.android.location" version="16.9.1"/>
          </group>
 
          <group targetFramework="Xamarin.iOS1.0">
-            <dependency id="airship.ios.core" version="16.11.2"/>
-            <dependency id="airship.ios.automation" version="16.11.2"/>
-            <dependency id="airship.ios.extendedactions" version="16.11.2"/>
-            <dependency id="airship.ios.messagecenter" version="16.11.2"/>
+            <dependency id="airship.ios.core" version="16.11.3"/>
+            <dependency id="airship.ios.automation" version="16.11.3"/>
+            <dependency id="airship.ios.extendedactions" version="16.11.3"/>
+            <dependency id="airship.ios.messagecenter" version="16.11.3"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.Accengage.nuspec
+++ b/Airship.iOS.Accengage.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.accengage</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Accengage</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Automation.nuspec
+++ b/Airship.iOS.Automation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.automation</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Automation</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Basement.nuspec
+++ b/Airship.iOS.Basement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.basement</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Basement</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Chat.nuspec
+++ b/Airship.iOS.Chat.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.chat</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Chat</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Core.nuspec
+++ b/Airship.iOS.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.core</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Core</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.ExtendedActions.nuspec
+++ b/Airship.iOS.ExtendedActions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.extendedactions</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - ExtendedActions</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Location.nuspec
+++ b/Airship.iOS.Location.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.location</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Location</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.MessageCenter.nuspec
+++ b/Airship.iOS.MessageCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.messagecenter</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - MessageCenter</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.NotificationContentExtension.nuspec
+++ b/Airship.iOS.NotificationContentExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.notificationcontentextension</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Notification Content Extension</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.NotificationServiceExtension.nuspec
+++ b/Airship.iOS.NotificationServiceExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.notificationserviceextension</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Notification Service Extension</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.PreferenceCenter.nuspec
+++ b/Airship.iOS.PreferenceCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.preferencecenter</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK - Preference Center</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.nuspec
+++ b/Airship.iOS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios</id>
-      <version>16.11.2</version>
+      <version>16.11.3</version>
       <title>Airship iOS SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,12 +11,12 @@
 
       <dependencies>
          <group>
-            <dependency id="airship.ios.basement" version="16.11.2"/>
-            <dependency id="airship.ios.core" version="16.11.2"/>
-            <dependency id="airship.ios.automation" version="16.11.2"/>
-            <dependency id="airship.ios.extendedactions" version="16.11.2"/>
-            <dependency id="airship.ios.messagecenter" version="16.11.2"/>
-            <dependency id="airship.ios.preferencecenter" version="16.11.2"/>
+            <dependency id="airship.ios.basement" version="16.11.3"/>
+            <dependency id="airship.ios.core" version="16.11.3"/>
+            <dependency id="airship.ios.automation" version="16.11.3"/>
+            <dependency id="airship.ios.extendedactions" version="16.11.3"/>
+            <dependency id="airship.ios.messagecenter" version="16.11.3"/>
+            <dependency id="airship.ios.preferencecenter" version="16.11.3"/>
          </group>
       </dependencies>
    </metadata>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Airship Xamarin Changelog
 
+## Version 17.0.2 - March 29, 2023
+Patch release that fixes Contact update merging order, improves Scene/Survey accessibility and reporting.
+
+### Changes
+- Updated iOS SDK to 16.11.3
+- Updated Android SDK to 16.9.1
+- Fixed Contact update merge order, resolving a Preference Center bug that could lead to unexpected subscription states in some circumstances.
+- Improved Scene/Survey accessibility and fixed a reporting bug related to form display events.
+
 ## Version 17.0.1 - March 17, 2023
-Minor release that fixes compatibility issues with v17.0.0. Maui support has been moved to a separate [repository](https://github.com/urbanairship/airship-dotnet) and artifacts under the `Airship.Net.*` package ID.
+Patch release that fixes compatibility issues with v17.0.0. Maui support has been moved to a separate [repository](https://github.com/urbanairship/airship-dotnet) and artifacts under the `Airship.Net.*` package ID.
 
 ### Changes
 - Updated iOS SDK to 16.11.2
@@ -13,7 +22,7 @@ This version contained native bindings incompatible with Xamarin projects.
 Apps upgrading from previous versions should update to the 17.0.1 release or later.
 
 ## Version 16.3.1 - March 2, 2023
-Minor release that updates to the latest Airship SDKs. The iOS SDK update fixes an issue with the Preference Center on iOS.
+Patch release that updates to the latest Airship SDKs. The iOS SDK update fixes an issue with the Preference Center on iOS.
 
 ### Changes
 - Updated iOS SDK to 16.11.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 16.11.2
+github "urbanairship/ios-library" == 16.11.3

--- a/airship.properties
+++ b/airship.properties
@@ -1,4 +1,4 @@
-crossPlatformVersion = 17.0.1
-iosNugetVersion = 16.11.2
-iosVersion = 16.11.2
-androidVersion = 16.9.0
+crossPlatformVersion = 17.0.2
+iosNugetVersion = 16.11.3
+iosVersion = 16.11.3
+androidVersion = 16.9.1

--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -68,7 +68,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-adm-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-adm-16.9.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets" Condition="Exists('packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets')" />

--- a/src/AirshipBindings.Android.Accengage/AirshipBindings.Android.Accengage.csproj
+++ b/src/AirshipBindings.Android.Accengage/AirshipBindings.Android.Accengage.csproj
@@ -89,7 +89,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-accengage-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-accengage-16.9.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/AirshipBindings.Android.Automation/AirshipBindings.Android.Automation.csproj
+++ b/src/AirshipBindings.Android.Automation/AirshipBindings.Android.Automation.csproj
@@ -151,7 +151,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-automation-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-automation-16.9.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -180,7 +180,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-core-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-core-16.9.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.AndroidX.Annotation.1.1.0\build\monoandroid90\Xamarin.AndroidX.Annotation.targets" Condition="Exists('packages\Xamarin.AndroidX.Annotation.1.1.0\build\monoandroid90\Xamarin.AndroidX.Annotation.targets')" />

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -207,7 +207,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-fcm-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-fcm-16.9.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets" Condition="Exists('packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets')" />

--- a/src/AirshipBindings.Android.Layout/AirshipBindings.Android.Layout.csproj
+++ b/src/AirshipBindings.Android.Layout/AirshipBindings.Android.Layout.csproj
@@ -61,7 +61,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-layout-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-layout-16.9.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Additions\" />

--- a/src/AirshipBindings.Android.Location/AirshipBindings.Android.Location.csproj
+++ b/src/AirshipBindings.Android.Location/AirshipBindings.Android.Location.csproj
@@ -66,7 +66,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-location-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-location-16.9.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/AirshipBindings.Android.MessageCenter/AirshipBindings.Android.MessageCenter.csproj
+++ b/src/AirshipBindings.Android.MessageCenter/AirshipBindings.Android.MessageCenter.csproj
@@ -162,7 +162,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-message-center-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-message-center-16.9.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/AirshipBindings.Android.Preference/AirshipBindings.Android.Preference.csproj
+++ b/src/AirshipBindings.Android.Preference/AirshipBindings.Android.Preference.csproj
@@ -160,7 +160,7 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-preference-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-preference-16.9.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AirshipBindings.Android.Core\AirshipBindings.Android.Core.csproj">

--- a/src/AirshipBindings.Android.PreferenceCenter/AirshipBindings.Android.PreferenceCenter.csproj
+++ b/src/AirshipBindings.Android.PreferenceCenter/AirshipBindings.Android.PreferenceCenter.csproj
@@ -225,7 +225,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-preference-center-16.9.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-preference-center-16.9.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/SharedAssemblyInfo.Android.cs
+++ b/src/SharedAssemblyInfo.Android.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("16.9.0")]
+[assembly: AssemblyVersion ("16.9.1")]
 

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("17.0.1")]
+[assembly: UACrossPlatformVersion ("17.0.2")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.0.1")]
+[assembly: AssemblyVersion ("17.0.2")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("16.11.2")]
+[assembly: AssemblyVersion ("16.11.3")]


### PR DESCRIPTION
## Version 17.0.2 - March 29, 2023
Patch release that fixes Contact update merging order, improves Scene/Survey accessibility and reporting.

### Changes
- Updated iOS SDK to 16.11.3
- Updated Android SDK to 16.9.1
- Fixed Contact update merge order, resolving a Preference Center bug that could lead to unexpected subscription states in some circumstances.
- Improved Scene/Survey accessibility and fixed a reporting bug related to form display events.

### Misc
- Also updated GCP actions and setting output in the release workflow.