### PR TITLE
[MOBILE-3542] Fix doc upload path in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,11 +66,11 @@ jobs:
         run: ./gradlew publishToProduction
 
       - name: Upload docs
-        uses: google-github-actions/upload-cloud-storage@v1
-        with:
-          path: docs/build/${{ steps.get_version.outputs.VERSION }}.tar.gz
-          destination: ua-web-ci-prod-docs-transfer/libraries/xamarin/${{ steps.get_version.outputs.VERSION }}.tar.gz
-
+        env:
+            VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          gsutil cp docs/build/$VERSION.tar.gz gs://ua-web-ci-prod-docs-transfer/libraries/xamarin/$VERSION.tar.gz
+          
       - name: Create Github Release
         uses: actions/create-release@v1.0.1
         env:


### PR DESCRIPTION
### What do these changes do?

Switches back to using `gsutil` for doc uploads, because the fancy action doesn't give as much control over the upload path and file name.

### Why are these changes necessary?

The doc bundle for the last release ended up at the wrong path.
