### PR TITLE
Add setup-gcloud to release workflow, to fix doc uploads

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,11 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
+      # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Fixing up the release workflow, which is failing on the doc upload step.