### PR TITLE
[MOBILE-4082] Fix missing custom event properties and log level trace->verbose on iOS

### DIFF
--- a/SampleApp/SampleApp.iOS/AppDelegate.cs
+++ b/SampleApp/SampleApp.iOS/AppDelegate.cs
@@ -30,7 +30,7 @@ namespace SampleApp.iOS
         {
             // Set log level for debugging config loading (optional)
             // It will be set to the value in the loaded config upon takeOff
-            UAirship.LogLevel = UALogLevel.Trace;
+            UAirship.LogLevel = UALogLevel.Verbose;
 
             // Populate AirshipConfig.plist with your app's info from https://go.urbanairship.com
             // or set runtime properties here.

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.iOS/Airship.cs
@@ -341,8 +341,7 @@ namespace UrbanAirship.NETStandard
                 }
                 if (propertyDictionary.Count > 0)
                 {
-                    //TODO: 
-                    //uaEvent.Properties = new NSDictionary<NSString, NSObject>(propertyDictionary.Keys, propertyDictionary.Values);
+                    uaEvent.Properties = new NSDictionary<NSString, NSObject>(propertyDictionary.Keys, propertyDictionary.Values);
                 }
             }
 

--- a/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
+++ b/src/AirshipBindings.iOS.Core/StructsAndEnums.cs
@@ -49,7 +49,9 @@ namespace UrbanAirship
 		Warn = 2,
 		Info = 3,
 		Debug = 4,
-		Trace = 5
+		[Obsolete("Use Verbose instead. Trace will be removed in a future release.")]
+		Trace = 5,
+		Verbose = 5
 	}
 
     [Native]


### PR DESCRIPTION
### What do these changes do?

- Uncomments the line that adds custom event properties to the native custom event object
- Deprecates `UALogLevel.Trace` and adds `UALogLevel.Verbose` (with the same value, so they'll do the same thing, but `Trace` will show a warning in the IDE)

### Why are these changes necessary?

Customer reported custom events were missing properties on iOS, and we changed the LogLevel in SDK 17, but missed the rename in this repo.

### How did you verify these changes?

* Reproduced the customer's issue using RTDS to view the payloads
* Wired up a custom event to a button on the sample app home screen and verified that the correct payloads with properties were showing up in the RTDS stream
* Migrated our single usage of `Trace` to `Verbose` and ran the sample app

