### PR TITLE
Release 18.1.0

### DIFF
--- a/Airship.Android.ADM.nuspec
+++ b/Airship.Android.ADM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.adm</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK - ADM Push Provider</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>A full suite of mobile engagement tools for building next-generation apps</description>
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.Automation.nuspec
+++ b/Airship.Android.Automation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.automation</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,8 +11,8 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
-            <dependency id="airship.android.layout" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
+            <dependency id="airship.android.layout" version="17.7.1"/>
             <dependency id="Xamarin.AndroidX.CustomView" version="1.1.0.4" />
             <dependency id="Xamarin.AndroidX.Room.Runtime" version="2.4.3"/>
          </group>

--- a/Airship.Android.Core.nuspec
+++ b/Airship.Android.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.core</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -16,9 +16,16 @@
             <dependency id="Xamarin.AndroidX.Core" version="1.6.0.3" />
             <dependency id="Xamarin.AndroidX.Concurrent.Futures" version="1.1.0.5" />
             <dependency id="Xamarin.AndroidX.Room.Runtime" version="2.4.3" />
+            <dependency id="Xamarin.AndroidX.Room.Room.Ktx" version="2.4.3" />
             <dependency id="Xamarin.AndroidX.Startup.StartupRuntime" version="1.1.0.2" />
             <dependency id="Xamarin.AndroidX.WebKit" version="1.3.0" />
             <dependency id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" />
+            <dependency id="Xamarin.Kotlin.StdLib" version="1.7.10" />
+            <dependency id="Xamarin.Kotlin.StdLib.Common" version="1.7.10" />
+            <dependency id="Xamarin.Kotlin.StdLib.Jdk7" version="1.7.10" />
+            <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.7.10" />
+            <dependency id="Xamarin.KotlinX.Coroutines.Android" version="1.6.4" />
+            <dependency id="Xamarin.KotlinX.Coroutines.Core.Jvm" version="1.6.4" />
          </group>
       </dependencies>
    </metadata>

--- a/Airship.Android.FCM.nuspec
+++ b/Airship.Android.FCM.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.fcm</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK - FCM Push Provider</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.Firebase.Messaging" version="122.0.0.1" />
             <dependency id="Xamarin.Google.Dagger" version="2.37.0" />
             <dependency id="Xamarin.GooglePlayServices.Base" version="117.6.0.1" />

--- a/Airship.Android.FeatureFlag.nuspec
+++ b/Airship.Android.FeatureFlag.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.featureflag</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK - Feature Flags</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.Kotlin.StdLib" version="1.5.31.2" />
             <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.5.31.2" />
             <dependency id="Xamarin.KotlinX.Coroutines.Android" version="1.5.2.2" />

--- a/Airship.Android.Layout.nuspec
+++ b/Airship.Android.Layout.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.layout</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.AndroidX.AppCompat" version="1.3.0"/>
             <dependency id="Xamarin.AndroidX.ConstraintLayout" version="2.1.1.2" />
             <dependency id="Xamarin.AndroidX.Core" version="1.6.0.3" />

--- a/Airship.Android.LiveUpdate.nuspec
+++ b/Airship.Android.LiveUpdate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.liveupdate</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.AndroidX.ConstraintLayout" version="2.1.1.2" />
             <dependency id="Xamarin.AndroidX.AppCompat" version="1.3"/>
          </group>

--- a/Airship.Android.MessageCenter.nuspec
+++ b/Airship.Android.MessageCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.messagecenter</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -12,7 +12,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
             <dependency id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.1.0.1" />
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.AndroidX.Room.Runtime" version="2.4.3"/>
          </group>
       </dependencies>

--- a/Airship.Android.PreferenceCenter.nuspec
+++ b/Airship.Android.PreferenceCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.android.preferencecenter</id>
-      <version>17.3.0</version>
+      <version>17.7.1</version>
       <title>Airship Android SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,7 +11,7 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
             <dependency id="Xamarin.AndroidX.AppCompat" version="1.3.1.3" />
             <dependency id="Xamarin.AndroidX.ConstraintLayout" version="2.1.1.2" />
             <dependency id="Xamarin.AndroidX.Core" version="1.6.0.3" />

--- a/Airship.NETStandard.nuspec
+++ b/Airship.NETStandard.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.netstandard</id>
-      <version>18.0.0</version>
+      <version>18.1.0</version>
       <title>Airship SDK .NET Standard Library</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -13,15 +13,15 @@
          <group targetFramework=".NETStandard2.0">
          </group>
          <group targetFramework="MonoAndroid4.1">
-            <dependency id="airship.android.core" version="17.3.0"/>
-            <dependency id="airship.android.messagecenter" version="17.3.0"/>
-            <dependency id="airship.android.automation" version="17.3.0"/>
+            <dependency id="airship.android.core" version="17.7.1"/>
+            <dependency id="airship.android.messagecenter" version="17.7.1"/>
+            <dependency id="airship.android.automation" version="17.7.1"/>
          </group>
 
          <group targetFramework="Xamarin.iOS1.0">
-            <dependency id="airship.ios.core" version="17.4.0"/>
-            <dependency id="airship.ios.automation" version="17.4.0"/>
-            <dependency id="airship.ios.messagecenter" version="17.4.0"/>
+            <dependency id="airship.ios.core" version="17.7.1"/>
+            <dependency id="airship.ios.automation" version="17.7.1"/>
+            <dependency id="airship.ios.messagecenter" version="17.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.Automation.nuspec
+++ b/Airship.iOS.Automation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.automation</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Automation</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Automation support for Airship SDK</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.core" version="17.4.0"/>
+          <dependency id="airship.ios.core" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.Basement.nuspec
+++ b/Airship.iOS.Basement.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.basement</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Basement</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>

--- a/Airship.iOS.Core.nuspec
+++ b/Airship.iOS.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.core</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Core</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Core of Airship SDK</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.basement" version="17.4.0"/>
+          <dependency id="airship.ios.basement" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.MessageCenter.nuspec
+++ b/Airship.iOS.MessageCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.messagecenter</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - MessageCenter</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Message center support for Airship SDK</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.core" version="17.4.0"/>
+          <dependency id="airship.ios.core" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.NotificationContentExtension.nuspec
+++ b/Airship.iOS.NotificationContentExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.notificationcontentextension</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Notification Content Extension</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Notification content extension support for iOS</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.core" version="17.4.0"/>
+          <dependency id="airship.ios.core" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.NotificationServiceExtension.nuspec
+++ b/Airship.iOS.NotificationServiceExtension.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.notificationserviceextension</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Notification Service Extension</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Notification service extension support for iOS</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.core" version="17.4.0"/>
+          <dependency id="airship.ios.core" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.PreferenceCenter.nuspec
+++ b/Airship.iOS.PreferenceCenter.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios.preferencecenter</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK - Preference Center</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -10,7 +10,7 @@
       <description>Preference Center support for Airship SDK</description>
       <dependencies>
         <group targetFramework="Xamarin.iOS1.0">
-          <dependency id="airship.ios.core" version="17.4.0"/>
+          <dependency id="airship.ios.core" version="17.7.1"/>
         </group>
       </dependencies>
    </metadata>

--- a/Airship.iOS.nuspec
+++ b/Airship.iOS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>airship.ios</id>
-      <version>17.4.0</version>
+      <version>17.7.1</version>
       <title>Airship iOS SDK</title>
       <authors>Airship, Inc.</authors>
       <projectUrl>https://github.com/urbanairship/urbanairship-xamarin</projectUrl>
@@ -11,11 +11,11 @@
 
       <dependencies>
          <group>
-            <dependency id="airship.ios.basement" version="17.4.0"/>
-            <dependency id="airship.ios.core" version="17.4.0"/>
-            <dependency id="airship.ios.automation" version="17.4.0"/>
-            <dependency id="airship.ios.messagecenter" version="17.4.0"/>
-            <dependency id="airship.ios.preferencecenter" version="17.4.0"/>
+            <dependency id="airship.ios.basement" version="17.7.1"/>
+            <dependency id="airship.ios.core" version="17.7.1"/>
+            <dependency id="airship.ios.automation" version="17.7.1"/>
+            <dependency id="airship.ios.messagecenter" version="17.7.1"/>
+            <dependency id="airship.ios.preferencecenter" version="17.7.1"/>
          </group>
       </dependencies>
    </metadata>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Airship Xamarin Changelog
 
-## Version 18.0.0 - October 4, 2024
+## Version 18.1.0 - January 22, 2024
+
+Minor release that updates to Airship SDK 17.7.1 and fixes an iOS custom event properties reporting issue. Apps that target iOS and make use of custom events should update.
+
+### Changes
+- Updated iOS SDK to 17.7.1
+- Updated Android SDK to 17.7.1
+- Fixed a bug that prevented custom event properties from being reported on iOS
+- Deprecated iOS `Trace` log level and add the replacement `Verbose` log level.
+
+## Version 18.0.0 - October 4, 2023
 Major release that updates to Airship SDK 17.x. This release adds support for Stories, In-App experiences downstream of a sequence in Journeys, and improves SDK auth. The Airship SDK now requires iOS 14+ as the minimum deployment version and Xcode 14.3+.
 
-## Changes
+### Changes
 - Updated iOS SDK to 17.4.0
 - Updated Android SDK to 17.3.0
 - Added the ability to update Channel and Contact subscriptions to the .NETStandard library

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "urbanairship/ios-library" == 17.4.0
+github "urbanairship/ios-library" == 17.7.1

--- a/SampleApp/SampleApp.Android/SampleApp.Android.csproj
+++ b/SampleApp/SampleApp.Android/SampleApp.Android.csproj
@@ -76,25 +76,25 @@
       <Version>1.3.1.3</Version>
     </PackageReference>
     <PackageReference Include="airship.android.fcm">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.preferencecenter">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.core">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.messagecenter">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.adm">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.automation">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
     <PackageReference Include="airship.android.layout">
-      <Version>17.3.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -91,7 +91,7 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2244" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="airship.ios">
-      <Version>17.4.0</Version>
+      <Version>17.7.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2244" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.Plugins.Clipboard" Version="2.3.0" />
-    <PackageReference Include="airship.netstandard" Version="18.0.0" />
+    <PackageReference Include="airship.netstandard" Version="18.1.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="AppResources.resx">

--- a/airship.properties
+++ b/airship.properties
@@ -1,4 +1,4 @@
-crossPlatformVersion = 18.0.0
-iosNugetVersion = 17.4.0
-iosVersion = 17.4.0
-androidVersion = 17.3.0
+crossPlatformVersion = 18.1.0
+iosNugetVersion = 17.7.1
+iosVersion = 17.7.1
+androidVersion = 17.7.1

--- a/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
+++ b/src/AirshipBindings.Android.ADM/AirshipBindings.Android.ADM.csproj
@@ -68,7 +68,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-adm-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-adm-17.7.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets" Condition="Exists('packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.targets')" />

--- a/src/AirshipBindings.Android.Automation/AirshipBindings.Android.Automation.csproj
+++ b/src/AirshipBindings.Android.Automation/AirshipBindings.Android.Automation.csproj
@@ -151,7 +151,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-automation-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-automation-17.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -145,13 +145,28 @@
       <HintPath>..\AirshipBindings.Android.Automation\packages\Xamarin.Jetbrains.Annotations.23.0.0.4\lib\monoandroid12.0\Xamarin.Jetbrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Kotlin.StdLib.Common">
-      <HintPath>..\AirshipBindings.Android.Automation\packages\Xamarin.Kotlin.StdLib.Common.1.7.0\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.Common.dll</HintPath>
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Common.1.7.10\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Kotlin.StdLib">
-      <HintPath>..\AirshipBindings.Android.Automation\packages\Xamarin.Kotlin.StdLib.1.7.0\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.dll</HintPath>
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.1.7.10\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.AndroidX.WebKit">
       <HintPath>packages\Xamarin.AndroidX.WebKit.1.3.0\lib\monoandroid90\Xamarin.AndroidX.WebKit.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Kotlin.StdLib.Jdk7">
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk7.1.7.10\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk7.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Kotlin.StdLib.Jdk8">
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk8.1.7.10\lib\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk8.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.KotlinX.Coroutines.Core.Jvm">
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Core.Jvm.1.6.4\lib\monoandroid12.0\Xamarin.KotlinX.Coroutines.Core.Jvm.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.KotlinX.Coroutines.Android">
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Android.1.6.4\lib\monoandroid12.0\Xamarin.KotlinX.Coroutines.Android.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Room.Room.Ktx">
+      <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.AndroidX.Room.Room.Ktx.2.4.3\lib\monoandroid12.0\Xamarin.AndroidX.Room.Room.Ktx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -183,7 +198,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-core-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-core-17.7.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.AndroidX.Annotation.1.1.0\build\monoandroid90\Xamarin.AndroidX.Annotation.targets" Condition="Exists('packages\Xamarin.AndroidX.Annotation.1.1.0\build\monoandroid90\Xamarin.AndroidX.Annotation.targets')" />
@@ -285,4 +300,11 @@
   <Import Project="..\AirshipBindings.Android.Automation\packages\Xamarin.AndroidX.Room.Runtime.2.4.3\build\monoandroid12.0\Xamarin.AndroidX.Room.Runtime.targets" Condition="Exists('..\AirshipBindings.Android.Automation\packages\Xamarin.AndroidX.Room.Runtime.2.4.3\build\monoandroid12.0\Xamarin.AndroidX.Room.Runtime.targets')" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.AndroidX.WebKit.1.3.0\build\monoandroid90\Xamarin.AndroidX.WebKit.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.AndroidX.WebKit.1.3.0\build\monoandroid90\Xamarin.AndroidX.WebKit.targets')" />
   <Import Project="packages\Xamarin.AndroidX.WebKit.1.3.0\build\monoandroid90\Xamarin.AndroidX.WebKit.targets" Condition="Exists('packages\Xamarin.AndroidX.WebKit.1.3.0\build\monoandroid90\Xamarin.AndroidX.WebKit.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Common.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Common.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Common.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Common.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk7.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk7.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk7.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk7.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk8.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk8.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Kotlin.StdLib.Jdk8.1.7.10\build\monoandroid12.0\Xamarin.Kotlin.StdLib.Jdk8.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Core.Jvm.1.6.4\build\monoandroid12.0\Xamarin.KotlinX.Coroutines.Core.Jvm.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Core.Jvm.1.6.4\build\monoandroid12.0\Xamarin.KotlinX.Coroutines.Core.Jvm.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Android.1.6.4\build\monoandroid12.0\Xamarin.KotlinX.Coroutines.Android.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.KotlinX.Coroutines.Android.1.6.4\build\monoandroid12.0\Xamarin.KotlinX.Coroutines.Android.targets')" />
+  <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.AndroidX.Room.Room.Ktx.2.4.3\build\monoandroid12.0\Xamarin.AndroidX.Room.Room.Ktx.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.AndroidX.Room.Room.Ktx.2.4.3\build\monoandroid12.0\Xamarin.AndroidX.Room.Room.Ktx.targets')" />
 </Project>

--- a/src/AirshipBindings.Android.Core/packages.config
+++ b/src/AirshipBindings.Android.Core/packages.config
@@ -22,6 +22,7 @@
   <package id="Xamarin.AndroidX.Migration" version="1.0.10" targetFramework="monoandroid12.0" />
   <package id="Xamarin.AndroidX.MultiDex" version="2.0.1.13" targetFramework="monoandroid12.0" />
   <package id="Xamarin.AndroidX.Room.Common" version="2.4.3" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.AndroidX.Room.Room.Ktx" version="2.4.3" targetFramework="monoandroid12.0" />
   <package id="Xamarin.AndroidX.Room.Runtime" version="2.4.3" targetFramework="monoandroid12.0" />
   <package id="Xamarin.AndroidX.SavedState" version="1.1.0.4" targetFramework="monoandroid10.0" />
   <package id="Xamarin.AndroidX.Sqlite" version="2.2.0.2" targetFramework="monoandroid12.0" />
@@ -34,6 +35,10 @@
   <package id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" targetFramework="monoandroid10.0" />
   <package id="Xamarin.Google.Guava.ListenableFuture" version="1.0.0.4" targetFramework="monoandroid10.0" />
   <package id="Xamarin.Jetbrains.Annotations" version="23.0.0.4" targetFramework="monoandroid12.0" />
-  <package id="Xamarin.Kotlin.StdLib" version="1.7.0" targetFramework="monoandroid12.0" />
-  <package id="Xamarin.Kotlin.StdLib.Common" version="1.7.0" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.Kotlin.StdLib" version="1.7.10" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.Kotlin.StdLib.Common" version="1.7.10" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.Kotlin.StdLib.Jdk7" version="1.7.10" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.Kotlin.StdLib.Jdk8" version="1.7.10" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.KotlinX.Coroutines.Android" version="1.6.4" targetFramework="monoandroid12.0" />
+  <package id="Xamarin.KotlinX.Coroutines.Core.Jvm" version="1.6.4" targetFramework="monoandroid12.0" />
 </packages>

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -207,7 +207,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-fcm-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-fcm-17.7.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <Import Project="packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets" Condition="Exists('packages\Xamarin.Build.Download.0.10.0\build\Xamarin.Build.Download.targets')" />

--- a/src/AirshipBindings.Android.FeatureFlag/AirshipBindings.Android.FeatureFlag.csproj
+++ b/src/AirshipBindings.Android.FeatureFlag/AirshipBindings.Android.FeatureFlag.csproj
@@ -54,7 +54,7 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-feature-flag-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-feature-flag-17.7.1.aar" />
   </ItemGroup>
    <ItemGroup>
     <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.6.4.2" PrivateAssets="none" />

--- a/src/AirshipBindings.Android.Layout/AirshipBindings.Android.Layout.csproj
+++ b/src/AirshipBindings.Android.Layout/AirshipBindings.Android.Layout.csproj
@@ -61,7 +61,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-layout-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-layout-17.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Additions\" />

--- a/src/AirshipBindings.Android.LiveUpdate/AirshipBindings.Android.LiveUpdate.csproj
+++ b/src/AirshipBindings.Android.LiveUpdate/AirshipBindings.Android.LiveUpdate.csproj
@@ -54,7 +54,7 @@
     <TransformFile Include="Transforms\EnumMethods.xml" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-live-update-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-live-update-17.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.6.4.2" PrivateAssets="none" />
@@ -63,6 +63,9 @@
       <Project>{98DC9E01-745C-4CEA-93A9-6546B349B8EE}</Project>
       <Name>AirshipBindings.Android.Core</Name>
     </ProjectReference>
+    <PackageReference Include="Xamarin.AndroidX.Core">
+      <Version>1.6.0.3</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/AirshipBindings.Android.MessageCenter/AirshipBindings.Android.MessageCenter.csproj
+++ b/src/AirshipBindings.Android.MessageCenter/AirshipBindings.Android.MessageCenter.csproj
@@ -162,7 +162,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-message-center-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-message-center-17.7.1.aar" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/AirshipBindings.Android.PreferenceCenter/AirshipBindings.Android.PreferenceCenter.csproj
+++ b/src/AirshipBindings.Android.PreferenceCenter/AirshipBindings.Android.PreferenceCenter.csproj
@@ -225,7 +225,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <LibraryProjectZip Include="Jars\urbanairship-preference-center-17.3.0.aar" />
+    <LibraryProjectZip Include="Jars\urbanairship-preference-center-17.7.1.aar" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.sln
+++ b/src/AirshipBindings.NETStandard/AirshipBindings.NETStandard.sln
@@ -23,6 +23,24 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.Mes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.Basement", "..\AirshipBindings.iOS.Basement\AirshipBindings.iOS.Basement.csproj", "{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.ADM", "..\AirshipBindings.Android.ADM\AirshipBindings.Android.ADM.csproj", "{FE05AF69-5F90-4918-8A11-E927110B043D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.FCM", "..\AirshipBindings.Android.FCM\AirshipBindings.Android.FCM.csproj", "{8EE00A82-2E14-4DF5-A183-52BBF17544A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.FeatureFlag", "..\AirshipBindings.Android.FeatureFlag\AirshipBindings.Android.FeatureFlag.csproj", "{F2B58B9A-3BE8-4C09-B91A-884F7BFA5716}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.Layout", "..\AirshipBindings.Android.Layout\AirshipBindings.Android.Layout.csproj", "{23A94840-FFAB-4E2E-A39E-2E054F2DD905}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.LiveUpdate", "..\AirshipBindings.Android.LiveUpdate\AirshipBindings.Android.LiveUpdate.csproj", "{34C41814-4889-4A78-AEF1-905951306C7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.Android.PreferenceCenter", "..\AirshipBindings.Android.PreferenceCenter\AirshipBindings.Android.PreferenceCenter.csproj", "{5D5C8FF3-09AF-4BB4-8953-C1F3856AAD47}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.NotificationContentExtension", "..\AirshipBindings.iOS.NotificationContentExtension\AirshipBindings.iOS.NotificationContentExtension.csproj", "{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.NotificationServiceExtension", "..\AirshipBindings.iOS.NotificationServiceExtension\AirshipBindings.iOS.NotificationServiceExtension.csproj", "{2C453988-C24E-431A-A17C-6989E93C795E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS.PreferenceCenter", "..\AirshipBindings.iOS.PreferenceCenter\AirshipBindings.iOS.PreferenceCenter.csproj", "{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,5 +95,41 @@ Global
 		{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E85A7FD-8C42-4DE6-B002-E3CC2DA529C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE05AF69-5F90-4918-8A11-E927110B043D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE05AF69-5F90-4918-8A11-E927110B043D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE05AF69-5F90-4918-8A11-E927110B043D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE05AF69-5F90-4918-8A11-E927110B043D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EE00A82-2E14-4DF5-A183-52BBF17544A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EE00A82-2E14-4DF5-A183-52BBF17544A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EE00A82-2E14-4DF5-A183-52BBF17544A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EE00A82-2E14-4DF5-A183-52BBF17544A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2B58B9A-3BE8-4C09-B91A-884F7BFA5716}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2B58B9A-3BE8-4C09-B91A-884F7BFA5716}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2B58B9A-3BE8-4C09-B91A-884F7BFA5716}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2B58B9A-3BE8-4C09-B91A-884F7BFA5716}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23A94840-FFAB-4E2E-A39E-2E054F2DD905}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23A94840-FFAB-4E2E-A39E-2E054F2DD905}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23A94840-FFAB-4E2E-A39E-2E054F2DD905}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23A94840-FFAB-4E2E-A39E-2E054F2DD905}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34C41814-4889-4A78-AEF1-905951306C7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34C41814-4889-4A78-AEF1-905951306C7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34C41814-4889-4A78-AEF1-905951306C7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34C41814-4889-4A78-AEF1-905951306C7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D5C8FF3-09AF-4BB4-8953-C1F3856AAD47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D5C8FF3-09AF-4BB4-8953-C1F3856AAD47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D5C8FF3-09AF-4BB4-8953-C1F3856AAD47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D5C8FF3-09AF-4BB4-8953-C1F3856AAD47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9325C9E-B43A-4BE8-AD68-B7BF6942F9F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C453988-C24E-431A-A17C-6989E93C795E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C453988-C24E-431A-A17C-6989E93C795E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C453988-C24E-431A-A17C-6989E93C795E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C453988-C24E-431A-A17C-6989E93C795E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13E9ACF2-4FE5-4FA6-96C4-BDFB6FF7C3A0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/SharedAssemblyInfo.Android.cs
+++ b/src/SharedAssemblyInfo.Android.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.3.0")]
+[assembly: AssemblyVersion ("17.7.1")]
 

--- a/src/SharedAssemblyInfo.Common.cs
+++ b/src/SharedAssemblyInfo.Common.cs
@@ -6,4 +6,4 @@ using UrbanAirship.Attributes;
 // Change them to the values specific to your project.
 
 // Cross-platform version of the plugin
-[assembly: UACrossPlatformVersion ("18.0.0")]
+[assembly: UACrossPlatformVersion ("18.1.0")]

--- a/src/SharedAssemblyInfo.CrossPlatform.cs
+++ b/src/SharedAssemblyInfo.CrossPlatform.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("18.0.0")]
+[assembly: AssemblyVersion ("18.1.0")]
 

--- a/src/SharedAssemblyInfo.iOS.cs
+++ b/src/SharedAssemblyInfo.iOS.cs
@@ -17,4 +17,4 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("17.4.0")]
+[assembly: AssemblyVersion ("17.7.1")]


### PR DESCRIPTION
## Version 18.1.0 - January 22, 2024

Minor release that updates to Airship SDK 17.7.1 and fixes an iOS custom event properties reporting issue. Apps that target iOS and make use of custom events should update.

### Changes
- Updated iOS SDK to 17.7.1
- Updated Android SDK to 17.7.1
- Fixed a bug that prevented custom event properties from being reported on iOS
- Deprecated iOS `Trace` log level and add the replacement `Verbose` log level.
